### PR TITLE
Remove old sound configuration menu

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -360,15 +360,6 @@
 						</binding>
 					</item>
 					<item>
-						<label>Adjust Sound Volumes</label>
-						<binding>
-							<command>nasal</command>
-							<script>
-							acconfig.sound_config_dlg.open();
-							</script>
-						</binding>
-					</item>
-					<item>
 						<label>Skip ADIRS</label>
 						<binding>
 							<command>property-assign</command>


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
<!-- Describe your changes in detail. -->
The sound configuration window was removed a few months ago.
This simply removes the corresponding item in the menu bar, which was left behind.

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->
`Utilities -> Adjust Sound Volumes` menu is non-functional.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
