### PR TITLE
8.33khz radio

### DIFF
--- a/Models/Instruments/Radio/Radio1.xml
+++ b/Models/Instruments/Radio/Radio1.xml
@@ -400,7 +400,7 @@
 						<not>
 							<equals>
 								<property>systems/radio/rmp[0]/vhf3-standby</property>
-								<value type="int">0</value>
+								<value>0</value>
 							</equals>
 						</not>
 					</and>
@@ -427,7 +427,7 @@
 						<not>
 							<equals>
 								<property>systems/radio/rmp[0]/vhf3-standby</property>
-								<value type="int">0</value>
+								<value>0</value>
 							</equals>
 						</not>
 					</and>
@@ -454,7 +454,7 @@
 						<not>
 							<equals>
 								<property>systems/radio/rmp[0]/vhf3-standby</property>
-								<value type="int">0</value>
+								<value>0</value>
 							</equals>
 						</not>
 					</and>
@@ -663,6 +663,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-assign</command>
@@ -684,6 +690,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -705,6 +717,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-assign</command>

--- a/Models/Instruments/Radio/Radio1.xml
+++ b/Models/Instruments/Radio/Radio1.xml
@@ -241,6 +241,11 @@
 
 	<!-- Knob -->
 	<!-- TODO add bindings for VOR, LS and ADF -->
+	<!-- We use a little hack to get 8.33MHz spacing working:
+		First we assign our current STBY freq we want to adjust to the default instrument.
+		Then we change the channel there.
+		Finally we assign the value back to out own prop.
+	-->
 	<animation>
 		<type>pick</type>
 		<object-name>radio_rot1</object-name>
@@ -266,14 +271,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[0]/vhf1-standby</property>
-				<step>0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -293,14 +335,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[0]/vhf2-standby</property>
-				<step>0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -321,19 +400,68 @@
 						<not>
 							<equals>
 								<property>systems/radio/rmp[0]/vhf3-standby</property>
-								<value>0</value>
+								<value type="int">0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value type="int">0</value>
 							</equals>
 						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value type="int">0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-assign</command>
 				<property>systems/radio/rmp[0]/vhf3-standby</property>
-				<step>0.025</step>
-				<resolution>0.025</resolution>
-				<min>0.0</min>
-				<max>1.0</max>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -409,14 +537,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[0]/vhf1-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -436,14 +601,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[0]/vhf2-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -461,22 +663,53 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
-						<not>
-							<equals>
-								<property>systems/radio/rmp[0]/vhf3-standby</property>
-								<value>0</value>
-							</equals>
-						</not>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
 					</and>
 				</condition>
 				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
 				<property>systems/radio/rmp[0]/vhf3-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>

--- a/Models/Instruments/Radio/Radio2.xml
+++ b/Models/Instruments/Radio/Radio2.xml
@@ -241,6 +241,11 @@
 
 	<!-- Knob -->
 	<!-- TODO add bindings for VOR, LS and ADF -->
+	<!-- We use a little hack to get 8.33MHz spacing working:
+		First we assign our current STBY freq we want to adjust to the default instrument.
+		Then we change the channel there.
+		Finally we assign the value back to out own prop.
+	-->
 	<animation>
 		<type>pick</type>
 		<object-name>radio_rot1</object-name>
@@ -266,14 +271,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf1-standby</property>
-				<step>0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -293,14 +335,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf2-standby</property>
-				<step>0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -326,14 +405,63 @@
 						</not>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf3-standby</property>
-				<step>0.025</step>
-				<resolution>0.025</resolution>
-				<min>0.0</min>
-				<max>1.0</max>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -409,14 +537,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf1-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -436,14 +601,51 @@
 						</equals>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf2-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>
@@ -469,14 +671,63 @@
 						</not>
 					</and>
 				</condition>
-				<command>property-adjust</command>
+				<command>property-assign</command>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 				<property>systems/radio/rmp[1]/vhf3-standby</property>
-				<step>-0.025</step>
-				<min>0.0</min>
-				<max>1.0</max>
-				<resolution>0.025</resolution>
-				<wrap>true</wrap>
-				<mask>decimal</mask>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>instrumentation/comm[0]/frequencies/standby-channel</property>
+				<step>-1</step>
+			</binding>
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
+					</and>
+				</condition>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<property>instrumentation/comm[0]/frequencies/standby-mhz</property>
 			</binding>
 
 			<binding>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -47,16 +47,19 @@
 	<comm-radio>
 		<name>comm</name>
 		<number>0</number>
+		<eight-point-three>1</eight-point-three>
 	</comm-radio>
 	
 	<comm-radio>
 		<name>comm</name>
 		<number>1</number>
+		<eight-point-three>1</eight-point-three>
 	</comm-radio>
 	
 	<comm-radio>
 		<name>comm</name>
 		<number>2</number>
+		<eight-point-three>1</eight-point-three>
 	</comm-radio>
 	
 	<dme>


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
Implementig 8.33KHz radio spacing (#12 ).

Using a little hack inspired by the 777 code:
* Freq gets copied from our props to the generic one
* We adjust the `standby-channel` there
* Then copy the value back

Done so to avoid trouble with steps (000 -> 005 -> 010 -> 015 -> 025).

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
