### PR TITLE
Set altimeter on 'Ready for Taxi' or 'Ready for Takeoff'

### DIFF
--- a/AircraftConfig/acconfig.nas
+++ b/AircraftConfig/acconfig.nas
@@ -481,6 +481,7 @@ var taxi_b = func {
 	setprop("/controls/lighting/taxi-light-switch", 0.5);
 	setprop("/controls/switches/landing-lights-l", 0.5);
 	setprop("/controls/switches/landing-lights-r", 0.5);
+	setprop("/instrumentation/altimeter[0]/setting-inhg", getprop("/environment/pressure-sea-level-inhg"));
 	settimer(taxi_c, 2);
 }
 var taxi_c = func {


### PR DESCRIPTION
### Description of Changes
Set altimeter on 'Ready for Taxi' or 'Ready for Takeoff'
- Gets in-hg from environment and sets to instrumentation (will automatically convert once added, if necessary)

### Bugs fixed (if any)
Adds feature request from #50 

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
