### PR TITLE
Add fallback model and interior model tags

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -15,6 +15,8 @@
 		</hud>
 
 		<model>
+			<fallback-model-index>212</fallback-model-index>
+
 			<autopush include="AircraftConfig/autopush-config.xml"/>
 			<icing>
 				<iceable>

--- a/Models/A320-100-CFM.xml
+++ b/Models/A320-100-CFM.xml
@@ -16,20 +16,17 @@
 		<path>Aircraft/A320-family/Models/Fuselages/A320-100/fuselage.xml</path>
 	</model>
 	
-	<!-- Separate Flightdeck to fit the modified nose -->
-	<model>
-		<name>Flightdeck</name>
-		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
-		<offsets>
-			<x-m>4.81794</x-m>
-			<y-m>0.0</y-m>
-			<z-m>0.0</z-m>
-		</offsets>
-	</model>
-	
 	<model>
 		<name>Interior</name>
-		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<path>Aircraft/A320-family/Models/A320-interior.xml</path>
+		<!-- On multiplayer models, the interior is loaded separately and global
+			 offsets are not applied. This cancels the global offsets, so that
+			 the interior is loaded at (0,0,0) anyway. -->
+		<offsets>
+			<x-m>18.8499</x-m>
+			<z-m>-1.7005004</z-m>
+		</offsets>
+		<usage>interior</usage>
 	</model>
 
 	<model>

--- a/Models/A320-200-CFM.xml
+++ b/Models/A320-200-CFM.xml
@@ -16,20 +16,17 @@
 		<path>Aircraft/A320-family/Models/Fuselages/A320/fuselage.xml</path>
 	</model>
 	
-	<!-- Separate Flightdeck to fit the modified nose -->
-	<model>
-		<name>Flightdeck</name>
-		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
-		<offsets>
-			<x-m>4.81794</x-m>
-			<y-m>0.0</y-m>
-			<z-m>0.0</z-m>
-		</offsets>
-	</model>
-	
 	<model>
 		<name>Interior</name>
-		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<path>Aircraft/A320-family/Models/A320-interior.xml</path>
+		<!-- On multiplayer models, the interior is loaded separately and global
+			 offsets are not applied. This cancels the global offsets, so that
+			 the interior is loaded at (0,0,0) anyway. -->
+		<offsets>
+			<x-m>18.8499</x-m>
+			<z-m>-1.7005004</z-m>
+		</offsets>
+		<usage>interior</usage>
 	</model>
 
 	<model>

--- a/Models/A320-200-IAE.xml
+++ b/Models/A320-200-IAE.xml
@@ -16,20 +16,17 @@
 		<path>Aircraft/A320-family/Models/Fuselages/A320/fuselage.xml</path>
 	</model>
 	
-	<!-- Separate Flightdeck to fit the modified nose -->
-	<model>
-		<name>Flightdeck</name>
-		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
-		<offsets>
-			<x-m>4.81794</x-m>
-			<y-m>0.0</y-m>
-			<z-m>0.0</z-m>
-		</offsets>
-	</model>
-	
 	<model>
 		<name>Interior</name>
-		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<path>Aircraft/A320-family/Models/A320-interior.xml</path>
+		<!-- On multiplayer models, the interior is loaded separately and global
+			 offsets are not applied. This cancels the global offsets, so that
+			 the interior is loaded at (0,0,0) anyway. -->
+		<offsets>
+			<x-m>18.8499</x-m>
+			<z-m>-1.7005004</z-m>
+		</offsets>
+		<usage>interior</usage>
 	</model>
 
 	<model>

--- a/Models/A320-interior.xml
+++ b/Models/A320-interior.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<PropertyList>
+	<!-- Separate Flightdeck to fit the modified nose -->
+	<model>
+		<name>Flightdeck</name>
+		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
+		<offsets>
+			<x-m>-14.0320</x-m>
+			<y-m>0.0</y-m>
+			<z-m>1.7005004</z-m>
+		</offsets>
+	</model>
+	
+	<model>
+		<name>Interior</name>
+		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<offsets>
+			<x-m>-18.8499</x-m>
+			<z-m>1.7005004</z-m>
+		</offsets>
+	</model>
+</PropertyList>

--- a/Models/A320neo-CFM.xml
+++ b/Models/A320neo-CFM.xml
@@ -16,20 +16,17 @@
 		<path>Aircraft/A320-family/Models/Fuselages/A320neo/fuselage.xml</path>
 	</model>
 	
-	<!-- Separate Flightdeck to fit the modified nose -->
-	<model>
-		<name>Flightdeck</name>
-		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
-		<offsets>
-			<x-m>4.81794</x-m>
-			<y-m>0.0</y-m>
-			<z-m>0.0</z-m>
-		</offsets>
-	</model>
-	
 	<model>
 		<name>Interior</name>
-		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<path>Aircraft/A320-family/Models/A320-interior.xml</path>
+		<!-- On multiplayer models, the interior is loaded separately and global
+			 offsets are not applied. This cancels the global offsets, so that
+			 the interior is loaded at (0,0,0) anyway. -->
+		<offsets>
+			<x-m>18.8499</x-m>
+			<z-m>-1.7005004</z-m>
+		</offsets>
+		<usage>interior</usage>
 	</model>
 
 	<model>

--- a/Models/A320neo-PW.xml
+++ b/Models/A320neo-PW.xml
@@ -16,20 +16,17 @@
 		<path>Aircraft/A320-family/Models/Fuselages/A320neo/fuselage.xml</path>
 	</model>
 	
-	<!-- Separate Flightdeck to fit the modified nose -->
-	<model>
-		<name>Flightdeck</name>
-		<path>Aircraft/A320-family/Models/FlightDeck/a320.flightdeck.xml</path>
-		<offsets>
-			<x-m>4.81794</x-m>
-			<y-m>0.0</y-m>
-			<z-m>0.0</z-m>
-		</offsets>
-	</model>
-	
 	<model>
 		<name>Interior</name>
-		<path>Aircraft/A320-family/Models/Interior/a320.interior.xml</path>
+		<path>Aircraft/A320-family/Models/A320-interior.xml</path>
+		<!-- On multiplayer models, the interior is loaded separately and global
+			 offsets are not applied. This cancels the global offsets, so that
+			 the interior is loaded at (0,0,0) anyway. -->
+		<offsets>
+			<x-m>18.8499</x-m>
+			<z-m>-1.7005004</z-m>
+		</offsets>
+		<usage>interior</usage>
 	</model>
 
 	<model>


### PR DESCRIPTION
### Description of Changes
Fixes #66

Regarding implementation of the `<usage>interior</usage>`
* I added the model file `A320-interior.xml` because only one part of the model can be marked as interior.
* When the interior is loaded separately on MP models, it is always loaded at position (0,0,0). In particular, the global offset is not applied. I worked around this by adjusting the offsets so as to load `A320-interior.xml` at (0,0,0) anyway, and then re-adding the offsets in the interior file.
I will gladly take a more elegant solution if you have an idea.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
