### PR TITLE
Throttle binding update

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1451,28 +1451,6 @@
 					<script>libraries.fovZoom(0);</script>
 				</binding>
 			</key>
-			<key n="33">
-				<name>PAGE UP</name>
-				<desc>Throttle Increase</desc>
-				<binding>
-					<command>nasal</command>
-					<script>
-						setprop("controls/engines/engine[0]/throttle", getprop("controls/engines/engine[0]/throttle") + 0.01);
-						setprop("controls/engines/engine[1]/throttle", getprop("controls/engines/engine[0]/throttle") + 0.01); # Not a typo, always use engine[0] as a reference
-					</script>
-				</binding>
-			</key>
-			<key n="34">
-				<name>PAGE DN</name>
-				<desc>Throttle Decrease</desc>
-				<binding>
-					<command>nasal</command>
-					<script>
-						setprop("controls/engines/engine[0]/throttle", getprop("controls/engines/engine[0]/throttle") - 0.01);
-						setprop("controls/engines/engine[1]/throttle", getprop("controls/engines/engine[0]/throttle") - 0.01); # Not a typo, always use engine[0] as a reference
-					</script>
-				</binding>
-			</key>
 			<key n="49">
 				<name>1</name>
 				<desc>Captain View/Elevator Trim Up</desc>

--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1509,8 +1509,7 @@
 					</condition>
 					<command>nasal</command>
 					<script>
-						setprop("controls/engines/engine[0]/throttle", getprop("controls/engines/engine[0]/throttle") - 0.01);
-						setprop("controls/engines/engine[1]/throttle", getprop("controls/engines/engine[0]/throttle") - 0.01); # Not a typo, always use engine[0] as a reference
+						controls.incThrottle(-0.01, -1.0);
 					</script>
 				</binding>
 			</key>
@@ -1637,8 +1636,7 @@
 					</condition>
 					<command>nasal</command>
 					<script>
-						setprop("controls/engines/engine[0]/throttle", getprop("controls/engines/engine[0]/throttle") + 0.01);
-						setprop("controls/engines/engine[1]/throttle", getprop("controls/engines/engine[0]/throttle") + 0.01); # Not a typo, always use engine[0] as a reference
+						controls.incThrottle(0.01, 1.0);
 					</script>
 				</binding>
 			</key>

--- a/Nasal/Systems/FADEC/engines-common.nas
+++ b/Nasal/Systems/FADEC/engines-common.nas
@@ -100,23 +100,37 @@ var apuBleedChk = maketimer(0.1, func {
 
 # Various Other Stuff
 var doIdleThrust = func {
+	# Idle does not respect selected engines, because it is used to respond
+	# to "Retard" and both engines must be idle for spoilers to deploy
 	setprop("controls/engines/engine[0]/throttle", 0.0);
 	setprop("controls/engines/engine[1]/throttle", 0.0);
 }
 
 var doCLThrust = func {
-	setprop("controls/engines/engine[0]/throttle", 0.63);
-	setprop("controls/engines/engine[1]/throttle", 0.63);
+	if (getprop("sim/input/selected/engine[0]") == 1) {
+		setprop("controls/engines/engine[0]/throttle", 0.63);
+	}
+	if (getprop("sim/input/selected/engine[1]") == 1) {
+		setprop("controls/engines/engine[1]/throttle", 0.63);
+	}
 }
 
 var doMCTThrust = func {
-	setprop("controls/engines/engine[0]/throttle", 0.8);
-	setprop("controls/engines/engine[1]/throttle", 0.8);
+	if (getprop("sim/input/selected/engine[0]") == 1) {
+		setprop("controls/engines/engine[0]/throttle", 0.8);
+	}
+	if (getprop("sim/input/selected/engine[1]") == 1) {
+		setprop("controls/engines/engine[1]/throttle", 0.8);
+	}
 }
 
 var doTOGAThrust = func {
-	setprop("controls/engines/engine[0]/throttle", 1.0);
-	setprop("controls/engines/engine[1]/throttle", 1.0);
+	if (getprop("sim/input/selected/engine[0]") == 1) {
+		setprop("controls/engines/engine[0]/throttle", 1.0);
+	}
+	if (getprop("sim/input/selected/engine[1]") == 1) {
+		setprop("controls/engines/engine[1]/throttle", 1.0);
+	}
 }
 
 # Reverse Thrust System

--- a/Nasal/Systems/FADEC/engines-common.nas
+++ b/Nasal/Systems/FADEC/engines-common.nas
@@ -138,15 +138,19 @@ var toggleFastRevThrust = func {
 	var state1 = getprop("systems/thrust/state1");
 	var state2 = getprop("systems/thrust/state2");
 	if (state1 == "IDLE" and state2 == "IDLE" and getprop("controls/engines/engine[0]/reverser") == "0" and getprop("controls/engines/engine[1]/reverser") == "0" and getprop("gear/gear[1]/wow") == 1 and getprop("gear/gear[2]/wow") == 1) {
-		interpolate("/engines/engine[0]/reverser-pos-norm", 1, 1.4);
-		interpolate("/engines/engine[1]/reverser-pos-norm", 1, 1.4);
-		setprop("controls/engines/engine[0]/reverser", 1);
-		setprop("controls/engines/engine[1]/reverser", 1);
-		setprop("controls/engines/engine[0]/throttle-rev", 0.65);
-		setprop("controls/engines/engine[1]/throttle-rev", 0.65);
-		setprop("fdm/jsbsim/propulsion/engine[0]/reverser-angle-rad", 3.14);
-		setprop("fdm/jsbsim/propulsion/engine[1]/reverser-angle-rad", 3.14);
-	} else if ((getprop("controls/engines/engine[0]/reverser") == "1") or (getprop("controls/engines/engine[1]/reverser") == "1") and (getprop("gear/gear[1]/wow") == 1) and (getprop("gear/gear[2]/wow") == 1)) {
+		if (getprop("sim/input/selected/engine[0]") == 1) {
+			interpolate("/engines/engine[0]/reverser-pos-norm", 1, 1.4);
+			setprop("controls/engines/engine[0]/reverser", 1);
+			setprop("controls/engines/engine[0]/throttle-rev", 0.65);
+			setprop("fdm/jsbsim/propulsion/engine[0]/reverser-angle-rad", 3.14);
+		}
+		if (getprop("sim/input/selected/engine[1]") == 1) {
+			interpolate("/engines/engine[1]/reverser-pos-norm", 1, 1.4);
+			setprop("controls/engines/engine[1]/reverser", 1);
+			setprop("controls/engines/engine[1]/throttle-rev", 0.65);
+			setprop("fdm/jsbsim/propulsion/engine[1]/reverser-angle-rad", 3.14);
+		}
+	} else if ((getprop("controls/engines/engine[0]/reverser") == "1") or (getprop("controls/engines/engine[1]/reverser") == "1")) {
 		setprop("controls/engines/engine[0]/throttle-rev", 0);
 		setprop("controls/engines/engine[1]/throttle-rev", 0);
 		interpolate("/engines/engine[0]/reverser-pos-norm", 0, 1.0);
@@ -159,54 +163,59 @@ var toggleFastRevThrust = func {
 }
 
 var doRevThrust = func {
-	if (getprop("controls/engines/engine[0]/reverser") == "1" and getprop("controls/engines/engine[1]/reverser") == "1" and getprop("gear/gear[1]/wow") == 1 and getprop("gear/gear[2]/wow") == 1) {
-		var pos1 = getprop("controls/engines/engine[0]/throttle-rev");
-		var pos2 = getprop("controls/engines/engine[1]/throttle-rev");
-		if (pos1 < 0.649) {
-			setprop("controls/engines/engine[0]/throttle-rev", pos1 + 0.15);
+	if (getprop("gear/gear[1]/wow") != 1 and getprop("gear/gear[2]/wow") != 1) {
+		# Can't select reverse if not on the ground
+		return;
+	}
+	if (getprop("sim/input/selected/engine[0]") == 1 and getprop("controls/engines/engine[0]/reverser") == "1") {
+		var pos = getprop("controls/engines/engine[0]/throttle-rev");
+		if (pos < 0.649) {
+			setprop("controls/engines/engine[0]/throttle-rev", pos + 0.15);
 		}
-		if (pos2 < 0.649) {
-			setprop("controls/engines/engine[1]/throttle-rev", pos2 + 0.15);
+	}
+	if (getprop("sim/input/selected/engine[1]") == 1 and getprop("controls/engines/engine[1]/reverser") == "1") {
+		var pos = getprop("controls/engines/engine[1]/throttle-rev");
+		if (pos < 0.649) {
+			setprop("controls/engines/engine[1]/throttle-rev", pos + 0.15);
 		}
 	}
 	var state1 = getprop("systems/thrust/state1");
 	var state2 = getprop("systems/thrust/state2");
-	if (state1 == "IDLE" and state2 == "IDLE" and getprop("controls/engines/engine[0]/reverser") == "0" and getprop("controls/engines/engine[1]/reverser") == "0" and getprop("gear/gear[1]/wow") == 1 and getprop("gear/gear[2]/wow") == 1) {
+	if (getprop("sim/input/selected/engine[0]") == 1 and state1 == "IDLE" and getprop("controls/engines/engine[0]/reverser") == "0") {
 		setprop("controls/engines/engine[0]/throttle-rev", 0.05);
-		setprop("controls/engines/engine[1]/throttle-rev", 0.05);
 		interpolate("/engines/engine[0]/reverser-pos-norm", 1, 1.4);
-		interpolate("/engines/engine[1]/reverser-pos-norm", 1, 1.4);
 		setprop("controls/engines/engine[0]/reverser", 1);
-		setprop("controls/engines/engine[1]/reverser", 1);
 		setprop("fdm/jsbsim/propulsion/engine[0]/reverser-angle-rad", 3.14);
+	}
+	if (getprop("sim/input/selected/engine[1]") == 1 and state2 == "IDLE" and getprop("controls/engines/engine[1]/reverser") == "0") {
+		setprop("controls/engines/engine[1]/throttle-rev", 0.05);
+		interpolate("/engines/engine[1]/reverser-pos-norm", 1, 1.4);
+		setprop("controls/engines/engine[1]/reverser", 1);
 		setprop("fdm/jsbsim/propulsion/engine[1]/reverser-angle-rad", 3.14);
 	}
 }
 
 var unRevThrust = func {
-	if (getprop("controls/engines/engine[0]/reverser") == "1" or getprop("controls/engines/engine[1]/reverser") == "1") {
-		var pos1 = getprop("controls/engines/engine[0]/throttle-rev");
-		var pos2 = getprop("controls/engines/engine[1]/throttle-rev");
-		if (pos1 > 0.051) {
-			setprop("controls/engines/engine[0]/throttle-rev", pos1 - 0.15);
+	if (getprop("sim/input/selected/engine[0]") == 1 and getprop("controls/engines/engine[0]/reverser") == "1") {
+		var pos = getprop("controls/engines/engine[0]/throttle-rev");
+		if (pos > 0.051) {
+			setprop("controls/engines/engine[0]/throttle-rev", pos - 0.15);
 		} else {
-			unRevThrust_b();
-		}
-		if (pos2 > 0.051) {
-			setprop("controls/engines/engine[1]/throttle-rev", pos2 - 0.15);
-		} else {
-			unRevThrust_b();
+			setprop("controls/engines/engine[0]/throttle-rev", 0);
+			interpolate("/engines/engine[0]/reverser-pos-norm", 0, 1.0);
+			setprop("fdm/jsbsim/propulsion/engine[0]/reverser-angle-rad", 0);
+			setprop("controls/engines/engine[0]/reverser", 0);
 		}
 	}
-}
-
-var unRevThrust_b = func {
-	setprop("controls/engines/engine[0]/throttle-rev", 0);
-	setprop("controls/engines/engine[1]/throttle-rev", 0);
-	interpolate("/engines/engine[0]/reverser-pos-norm", 0, 1.0);
-	interpolate("/engines/engine[1]/reverser-pos-norm", 0, 1.0);
-	setprop("fdm/jsbsim/propulsion/engine[0]/reverser-angle-rad", 0);
-	setprop("fdm/jsbsim/propulsion/engine[1]/reverser-angle-rad", 0);
-	setprop("controls/engines/engine[0]/reverser", 0);
-	setprop("controls/engines/engine[1]/reverser", 0);
+	if (getprop("sim/input/selected/engine[1]") == 1 and getprop("controls/engines/engine[1]/reverser") == "1") {
+		var pos = getprop("controls/engines/engine[1]/throttle-rev");
+		if (pos > 0.051) {
+			setprop("controls/engines/engine[1]/throttle-rev", pos - 0.15);
+		} else {
+			setprop("controls/engines/engine[1]/throttle-rev", 0);
+			interpolate("/engines/engine[1]/reverser-pos-norm", 0, 1.0);
+			setprop("fdm/jsbsim/propulsion/engine[1]/reverser-angle-rad", 0);
+			setprop("controls/engines/engine[1]/reverser", 0);
+		}
+	}
 }


### PR DESCRIPTION
Remove inconsistent thrust lever bindings and make thrust lever handling respect selected engines.

### Description of Changes

I have looked up what key bindings there are and noticed there were bindings that said they are for `PgUp` and `PgDn`, but had `key n="33"` and `n="34"`, which are `@` and `"` respectively. The
bindings were intended to override the default thrust increase/decrease, but because of this
mismatch, didn't do it.

The default bindings seem to do their job fine, and worse, my testing showed the right thrust lever
strangely lagging behind the left when I put these bindings in their intended place, so I decided to
remove them instead.

I then removed the code from the `9` and `3` bindings in Keyboard mode to make them consistent,
and then I proceeded to add support for selecting engines to the other functions:

- `f` (TOGA), `Ctrl-f` (MCT/FLX) and `F` (CL) now only adjust the selected engine(s).
- `F1`/`F2` (dec/inc reverse) only adjust the selected engine(s).
- `del` (toggle reverse) only engages reverse on the selected engine(s).
- However `e` (idle) selected idle on both engines and `del` disengages reverse on both engines if it is selected on either. This is so you don't get left with high power or reverse by accident when selecting engines.

Selecting engines can be useful for engine-out operation, when the thrust lever of the failed engine is supposed to stay in idle.

### Screenshots (optional)

Not applicable

### Bugs fixed (if any)

Fixes inconsistent keyboard bindings. Was not filed as a separate issue.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->

Please check with autopilot. The default thrust lever bindings have special logic for the default autopilot triggered by properties `/autopilot/locks/passive-mode` and `/autopilot/locks/speed` that shouldn't apply here. I don't think the properties would get set here, but in case I missed something.