### PR TITLE
Fix gear compression animation over MP

### DIFF
--- a/Models/LandingGears/a320.mlg.left.xml
+++ b/Models/LandingGears/a320.mlg.left.xml
@@ -112,7 +112,7 @@
 		<object-name>ACTUTATOR</object-name>
 		<object-name>Main Tires</object-name>
 		<object-name>Compression lower scissor</object-name>
-		<property>gear/gear[1]/compression-ft</property>
+		<property>gear/gear[1]/compression-norm</property>
 		<factor>0.305</factor>
 		<axis>
 			<x1-m>0</x1-m>

--- a/Models/LandingGears/a320.mlg.right.xml
+++ b/Models/LandingGears/a320.mlg.right.xml
@@ -112,7 +112,7 @@
 		<object-name>ACTUTATOR</object-name>
 		<object-name>Main Tires</object-name>
 		<object-name>Compression lower scissor</object-name>
-		<property>gear/gear[2]/compression-ft</property>
+		<property>gear/gear[2]/compression-norm</property>
 		<factor>0.305</factor>
 		<axis>
 			<x1-m>0</x1-m>

--- a/Models/LandingGears/a320.nlg.xml
+++ b/Models/LandingGears/a320.nlg.xml
@@ -112,7 +112,7 @@
 		<object-name>AXLE</object-name>
 		<object-name>Nose Tires</object-name>
 		<object-name>Compression lower scissor</object-name>
-		<property>gear/gear[0]/compression-ft</property>
+		<property>gear/gear[0]/compression-norm</property>
 		<factor>0.305</factor>
 		<axis>
 			<x1-m>-0.366</x1-m>


### PR DESCRIPTION
### Description of Changes
Replaces `gear[i]/compression-ft` with `gear[i]/compression-norm`. 
They are equivalent, but only the latter is transmitted on MP.

### Bugs fixed (if any)
Gears do not compressed on multiplayer models.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
