### PR TITLE
Fix flx formatting, support 0-99 heading entry on ILS CRS

### DIFF
--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -384,7 +384,7 @@ var canvas_PFD_base = {
 				me["FMA_man_box"].hide();
 				me["FMA_flx_box"].show();
 				me["FMA_flxtemp"].show();
-				me["FMA_manmode"].setText("FLX			  ");
+				me["FMA_manmode"].setText("FLX            ");
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			} else if ((state1_act == "MAN THR" and thr1_act < 0.83) or (state2_act == "MAN THR" and thr2_act < 0.83)) {
 				me["FMA_flx_box"].hide();

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -216,7 +216,7 @@ var canvas_PFD_base = {
 		return me;
 	},
 	getKeys: func() {
-		return ["FMA_man","FMA_manmode","FMA_flxtemp","FMA_thrust","FMA_lvrclb","FMA_pitch","FMA_pitcharm","FMA_pitcharm2","FMA_roll","FMA_rollarm","FMA_combined","FMA_ctr_msg","FMA_catmode","FMA_cattype","FMA_nodh","FMA_dh","FMA_dhn","FMA_ap","FMA_fd","FMA_athr",
+		return ["FMA_man","FMA_manmode","FMA_flxmode","FMA_flxtemp","FMA_thrust","FMA_lvrclb","FMA_pitch","FMA_pitcharm","FMA_pitcharm2","FMA_roll","FMA_rollarm","FMA_combined","FMA_ctr_msg","FMA_catmode","FMA_cattype","FMA_nodh","FMA_dh","FMA_dhn","FMA_ap","FMA_fd","FMA_athr",
 		"FMA_man_box","FMA_flx_box","FMA_thrust_box","FMA_pitch_box","FMA_pitcharm_box","FMA_roll_box","FMA_rollarm_box","FMA_combined_box","FMA_catmode_box","FMA_cattype_box","FMA_cat_box","FMA_dh_box","FMA_ap_box","FMA_fd_box","FMA_athr_box","FMA_Middle1",
 		"FMA_Middle2","ASI_max","ASI_scale","ASI_target","ASI_mach","ASI_mach_decimal","ASI_trend_up","ASI_trend_down","ASI_digit_UP","ASI_digit_DN","ASI_decimal_UP","ASI_decimal_DN","ASI_index","ASI_error","ASI_group","ASI_frame","AI_center","AI_bank",
 		"AI_bank_lim","AI_bank_lim_X","AI_pitch_lim","AI_pitch_lim_X","AI_slipskid","AI_horizon","AI_horizon_ground","AI_horizon_sky","AI_stick","AI_stick_pos","AI_heading","AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","ALT_box_flash","ALT_box","ALT_box_amber",
@@ -360,23 +360,28 @@ var canvas_PFD_base = {
 		if (athr.getValue() == 1 and (state1_act == "TOGA" or state1_act == "MCT" or state1_act == "MAN THR" or state2_act == "TOGA" or state2_act == "MCT" or state2_act == "MAN THR") and eng_out.getValue() != 1 and alpha_floor_act != 1 and 
 		toga_lk_act != 1) {
 			me["FMA_man"].show();
-			me["FMA_manmode"].show();
 			if (state1_act == "TOGA" or state2_act == "TOGA") {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("TOGA");
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			} else if ((state1_act == "MAN THR" and thr1_act >= 0.83) or (state2_act == "MAN THR" and thr2_act >= 0.83)) {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("THR");
 				me["FMA_man_box"].setColor(0.7333,0.3803,0);
 			} else if ((state1_act == "MCT" or state2_act == "MCT") and thrust_limit_act != "FLX") {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("MCT");
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			} else if ((state1_act == "MCT" or state2_act == "MCT") and thrust_limit_act == "FLX") {
@@ -384,29 +389,35 @@ var canvas_PFD_base = {
 				me["FMA_man_box"].hide();
 				me["FMA_flx_box"].show();
 				me["FMA_flxtemp"].show();
-				me["FMA_manmode"].setText("FLX            ");
+				me["FMA_manmode"].hide();
+				me["FMA_flxmode"].show();
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			} else if ((state1_act == "MAN THR" and thr1_act < 0.83) or (state2_act == "MAN THR" and thr2_act < 0.83)) {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("THR");
 				me["FMA_man_box"].setColor(0.7333,0.3803,0);
 			}
 		} else if (athr.getValue() == 1 and (state1_act == "TOGA" or (state1_act == "MCT" and thrust_limit_act == "FLX") or (state1_act == "MAN THR" and thr1_act >= 0.83) or state2_act == "TOGA" or (state2_act == "MCT" and 
 		thrust_limit_act == "FLX") or (state2_act == "MAN THR" and thr2_act >= 0.83)) and eng_out.getValue() == 1 and alpha_floor_act != 1 and toga_lk_act != 1) {
 			me["FMA_man"].show();
-			me["FMA_manmode"].show();
 			if (state1_act == "TOGA" or state2_act == "TOGA") {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("TOGA");
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			} else if ((state1_act == "MAN THR" and thr1_act >= 0.83) or (state2_act == "MAN THR" and thr2_act >= 0.83)) {
 				me["FMA_flx_box"].hide();
 				me["FMA_flxtemp"].hide();
 				me["FMA_man_box"].show();
+				me["FMA_manmode"].show();
+				me["FMA_flxmode"].hide();
 				me["FMA_manmode"].setText("THR");
 				me["FMA_man_box"].setColor(0.7333,0.3803,0);
 			} else if ((state1_act == "MCT" or state2_act == "MCT") and thrust_limit_act == "FLX") {
@@ -414,7 +425,8 @@ var canvas_PFD_base = {
 				me["FMA_man_box"].hide();
 				me["FMA_flx_box"].show();
 				me["FMA_flxtemp"].show();
-				me["FMA_manmode"].setText("FLX			  ");
+				me["FMA_manmode"].hide();
+				me["FMA_flxmode"].show();
 				me["FMA_man_box"].setColor(0.8078,0.8039,0.8078);
 			}
 		} else {
@@ -423,6 +435,7 @@ var canvas_PFD_base = {
 			me["FMA_man_box"].hide();
 			me["FMA_flx_box"].hide();
 			me["FMA_flxtemp"].hide();
+			me["FMA_flxmode"].hide();
 		}
 		
 		if ((state1_act == "CL" and state2_act != "CL") or (state1_act != "CL" and state2_act == "CL") and eng_out.getValue() != 1) {
@@ -870,12 +883,24 @@ var canvas_PFD_base = {
 				me["ILS_HDG_L"].hide();
 				me["CRS_pointer"].show();
 			} else if (magnetic_hdg_dif < -23.62 and magnetic_hdg_dif >= -180) {
-				me["ILS_left"].setText(sprintf("%3.0f", int(magnetic_hdg)));
+				if (int(magnetic_hdg) < 10) {
+					me["ILS_left"].setText(sprintf("00%1.0f", int(magnetic_hdg)));
+				} else if (int(magnetic_hdg) < 100) {
+					me["ILS_left"].setText(sprintf("0%2.0f", int(magnetic_hdg)));
+				} else {
+					me["ILS_left"].setText(sprintf("%3.0f", int(magnetic_hdg)));
+				}
 				me["ILS_HDG_L"].show();
 				me["ILS_HDG_R"].hide();
 				me["CRS_pointer"].hide();
 			} else if (magnetic_hdg_dif > 23.62 and magnetic_hdg_dif <= 180) {
-				me["ILS_right"].setText(sprintf("%3.0f", int(magnetic_hdg)));
+				if (int(magnetic_hdg) < 10) {
+					me["ILS_right"].setText(sprintf("00%1.0f", int(magnetic_hdg)));
+				} else if (int(magnetic_hdg) < 100) {
+					me["ILS_right"].setText(sprintf("0%2.0f", int(magnetic_hdg)));
+				} else {
+					me["ILS_right"].setText(sprintf("%3.0f", int(magnetic_hdg)));
+				}
 				me["ILS_HDG_R"].show();
 				me["ILS_HDG_L"].hide();
 				me["CRS_pointer"].hide();

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   sodipodi:docname="pfd.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   id="svg2"
-   version="1.1"
-   viewBox="0 0 1024 1024"
+   width="1024pt"
    height="1024pt"
-   width="1024pt">
+   viewBox="0 0 1024 1024"
+   version="1.1"
+   id="svg2"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="pfd.svg">
   <metadata
      id="metadata375">
     <rdf:RDF>
@@ -29,50 +29,42 @@
   <defs
      id="defs373" />
   <sodipodi:namedview
-     inkscape:document-rotation="0"
-     fit-margin-bottom="0"
-     fit-margin-right="0"
-     fit-margin-left="0"
-     fit-margin-top="0"
-     units="pt"
-     inkscape:snap-global="false"
-     showguides="true"
-     inkscape:current-layer="ALT_group"
-     inkscape:window-maximized="0"
-     inkscape:window-y="23"
-     inkscape:window-x="0"
-     inkscape:cy="682.32051"
-     inkscape:cx="984.6696"
-     inkscape:zoom="2.2980412"
-     showgrid="true"
-     id="namedview371"
-     inkscape:window-height="729"
-     inkscape:window-width="1280"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="1"
-     guidetolerance="10"
-     gridtolerance="10"
-     objecttolerance="20"
-     borderopacity="1"
+     pagecolor="#000000"
      bordercolor="#666666"
-     pagecolor="#000000">
+     borderopacity="1"
+     objecttolerance="20"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="729"
+     id="namedview371"
+     showgrid="true"
+     inkscape:zoom="2.2980412"
+     inkscape:cx="120.45533"
+     inkscape:cy="111.3995"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:snap-global="false"
+     units="pt"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:document-rotation="0">
     <inkscape:grid
-       originy="0"
-       originx="0"
+       type="xygrid"
        id="grid5153"
-       type="xygrid" />
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <rect
-     inkscape:label="#rect9211"
-     y="229.74361"
-     x="203.79523"
-     height="562.93713"
-     width="489.23914"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="AI_horizon_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="AI_horizon_ground_clip"
      width="489.23914"
      height="562.93713"
      x="203.79523"
@@ -84,1304 +76,1336 @@
      x="203.79523"
      height="562.93713"
      width="489.23914"
-     id="AI_horizon_sky_clip"
+     id="AI_horizon_ground_clip"
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="AI_heading_clip"
-     width="481.22961"
-     height="562.93683"
-     x="207.51085"
-     y="229.74397"
+     id="AI_horizon_sky_clip"
+     width="489.23914"
+     height="562.93713"
+     x="203.79523"
+     y="229.74361"
      inkscape:label="#rect9211" />
+  <rect
+     inkscape:label="#rect9211"
+     y="229.74397"
+     x="207.51085"
+     height="562.93683"
+     width="481.22961"
+     id="AI_heading_clip"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <g
-     inkscape:label="#g4891"
-     id="AI_group">
+     id="AI_group"
+     inkscape:label="#g4891">
     <g
-       id="AI_horizon"
+       inkscape:label="#g5497"
        transform="translate(0,-97.082454)"
-       inkscape:label="#g5497">
+       id="AI_horizon">
       <g
-         inkscape:label="#g5492"
-         id="AI_background">
-        <rect
-           style="opacity:1;fill:#522001;fill-opacity:1;stroke:none;stroke-width:2.48752213;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="AI_ground"
-           width="1287.3097"
-           height="1102.3192"
-           x="-195.3976"
-           y="611.74884"
-           inkscape:label="#rect5809" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m -193.7976,610.26868 1284.1095,0"
-           id="path4602"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+         id="AI_background"
+         inkscape:label="#g5492">
         <rect
            inkscape:label="#rect5809"
-           y="-493.56796"
-           x="-195.39726"
-           height="1102.3193"
-           width="1287.3096"
+           y="611.74884"
+           x="-195.3976"
+           height="1102.3192"
+           width="1287.3097"
+           id="AI_ground"
+           style="opacity:1;fill:#522001;fill-opacity:1;stroke:none;stroke-width:2.48752213;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4602"
+           d="m -193.7976,610.26868 1284.1095,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <rect
+           style="opacity:1;fill:#368acd;fill-opacity:1;stroke:none;stroke-width:2.58921981;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="AI_sky"
-           style="opacity:1;fill:#368acd;fill-opacity:1;stroke:none;stroke-width:2.58921981;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+           width="1287.3096"
+           height="1102.3193"
+           x="-195.39726"
+           y="-493.56796"
+           inkscape:label="#rect5809" />
       </g>
       <g
-         inkscape:label="#g5341"
-         id="AI_scale">
+         id="AI_scale"
+         inkscape:label="#g5341">
         <g
-           id="AI_sky_scale"
-           inkscape:label="#g4851">
+           inkscape:label="#g4851"
+           id="AI_sky_scale">
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,580.702 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4684"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,580.702 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4686"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,521.5684 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4686"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,492.0016 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4688"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,492.0016 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,432.86803 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5071"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,432.86803 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5073"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,462.4348 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5073"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,403.3012 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5075"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,403.3012 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5077"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,373.7344 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path5077"
              inkscape:connector-curvature="0"
-             id="path5117"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,314.60083 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5117"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,344.1676 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5119"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,344.1676 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5121"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,285.034 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5121"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,255.4672 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5123"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,255.4672 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,196.33363 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5133"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,196.33363 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5135"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,225.9004 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5135"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,166.7668 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5137"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,166.7668 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5139"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,137.2 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path5139"
              inkscape:connector-curvature="0"
-             id="path5149"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,78.066427 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5149"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,107.6332 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5151"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,107.6332 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5153"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,48.499597 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5153"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,18.932797 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5155"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,18.932797 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,-40.200773 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5165"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,-40.200773 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5167"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,-10.634 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5167"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,-69.767603 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5169"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,-69.767603 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5171"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,-99.334403 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path5171"
              inkscape:connector-curvature="0"
-             id="path5181"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,-158.46797 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5181"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,-128.9012 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5183"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,-128.9012 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5185"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,-188.0348 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5185"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,-217.6016 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5187"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,-217.6016 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,-276.73517 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5197"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,-276.73517 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5199"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,-247.1684 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5199"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,-306.302 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5201"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,-306.302 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5203"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,-335.8688 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path5203"
              inkscape:connector-curvature="0"
-             id="path5213"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,-395.00237 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5213"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,-365.4356 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5215"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,-365.4356 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path5217"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,-424.5692 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path5217"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,-454.136 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path5219"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,-454.136 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,551.13523 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4505"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,551.13523 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         </g>
         <g
-           id="AI_ground_scale"
-           inkscape:label="#g4813">
+           inkscape:label="#g4813"
+           id="AI_ground_scale">
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4503"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,639.8352 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4503"
              inkscape:connector-curvature="0"
-             id="path4507"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,669.402 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4507"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,698.9688 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4509"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,698.9688 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4511"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,728.5356 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4511"
              inkscape:connector-curvature="0"
-             id="path4521"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,758.1028 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4521"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,787.6696 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4523"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,787.6696 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,817.2364 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4525"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,817.2364 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,846.8032 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4527"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,846.8032 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4529"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,876.37 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4529"
              inkscape:connector-curvature="0"
-             id="path4531"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,905.9368 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4531"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,935.5036 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4533"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,935.5036 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4535"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,965.0704 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4535"
              inkscape:connector-curvature="0"
-             id="path4565"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,994.63724 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4565"
              inkscape:connector-curvature="0"
-             id="path4567"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,1024.204 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4567"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1053.7708 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4569"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,1053.7708 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4571"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,1083.3376 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4571"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1112.9044 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4573"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,1112.9044 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,1142.4712 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4575"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,1142.4712 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4577"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,1172.038 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4577"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,1201.6048 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4579"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,1201.6048 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4597"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,1231.1716 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4597"
              inkscape:connector-curvature="0"
-             id="path4599"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,1260.7384 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4599"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1290.3052 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4601"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,1290.3052 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4603"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,1319.872 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4603"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1349.4388 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4605"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,1349.4388 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,1379.0056 55.30952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4607"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 420.6008,1379.0056 55.30952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4609"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,1408.5724 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4609"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,1438.1392 109.26112,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4611"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 393.624,1438.1392 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4629"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 433.99987,1467.706 28.50952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path4629"
              inkscape:connector-curvature="0"
-             id="path4631"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 420.6008,1497.2728 55.30952,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             id="path4631"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1526.8396 28.50952,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4633"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 433.99987,1526.8396 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4635"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 393.624,1556.4064 109.26112,0"
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-          <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 433.99987,1585.9732 28.50952,0"
-             id="path4637"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
-          <path
-             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 420.6008,1615.54 55.30952,0"
-             id="path4639"
+             id="path4635"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
           <path
              sodipodi:nodetypes="cc"
              inkscape:connector-curvature="0"
-             id="path4641"
-             d="m 433.99987,1645.1068 28.50952,0"
+             id="path4637"
+             d="m 433.99987,1585.9732 28.50952,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path4639"
+             d="m 420.6008,1615.54 55.30952,0"
              style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
              style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 393.624,1674.6736 109.26112,0"
-             id="path4643"
+             d="m 433.99987,1645.1068 28.50952,0"
+             id="path4641"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path4643"
+             d="m 393.624,1674.6736 109.26112,0"
+             style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         </g>
         <g
-           id="AI_scale_num"
-           inkscape:label="#g4737">
+           inkscape:label="#g4737"
+           id="AI_scale_num">
           <g
-             inkscape:label="#g4699"
-             id="AI_sky_num">
-            <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text4718"
-               y="480.29712"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="480.29712"
-                 x="381.24359"
-                 id="tspan4720"
-                 sodipodi:role="line">10</tspan></text>
+             id="AI_sky_num"
+             inkscape:label="#g4699">
             <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="593.11237"
-               y="480.29608"
-               id="text5079"
-               transform="scale(0.95383073,1.0484041)"
+               x="381.24359"
+               y="480.29712"
+               id="text4718"
+               transform="scale(0.95383277,1.0484018)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan5081"
-                 x="593.11237"
-                 y="480.29608"
+                 id="tspan4720"
+                 x="381.24359"
+                 y="480.29712"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">10</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="367.48999"
-               id="text5092"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan5095"
-                 x="381.24359"
-                 y="367.48999"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">20</tspan></text>
-            <text
                inkscape:label="#text975"
-               transform="scale(0.9538307,1.0484041)"
-               id="text5097"
-               y="367.4892"
+               transform="scale(0.95383073,1.0484041)"
+               id="text5079"
+               y="480.29608"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="367.4892"
+                 y="480.29608"
                  x="593.11237"
-                 id="tspan5099"
+                 id="tspan5081"
+                 sodipodi:role="line">10</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text5092"
+               y="367.48999"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="367.48999"
+                 x="381.24359"
+                 id="tspan5095"
                  sodipodi:role="line">20</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text5125"
-               y="254.68286"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="254.68286"
-                 x="381.24359"
-                 id="tspan5127"
-                 sodipodi:role="line">30</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="254.68231"
-               id="text5129"
-               transform="scale(0.95383069,1.0484041)"
+               y="367.4892"
+               id="text5097"
+               transform="scale(0.9538307,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan5131"
+                 id="tspan5099"
                  x="593.11237"
-                 y="254.68231"
+                 y="367.4892"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">20</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="254.68286"
+               id="text5125"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan5127"
+                 x="381.24359"
+                 y="254.68286"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">30</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="141.87573"
-               id="text5141"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan5143"
-                 x="381.24359"
-                 y="141.87573"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">40</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text5145"
-               y="141.87543"
+               id="text5129"
+               y="254.68231"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="141.87543"
+                 y="254.68231"
                  x="593.11237"
-                 id="tspan5147"
+                 id="tspan5131"
+                 sodipodi:role="line">30</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text5141"
+               y="141.87573"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="141.87573"
+                 x="381.24359"
+                 id="tspan5143"
                  sodipodi:role="line">40</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text5157"
-               y="29.0686"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="29.0686"
-                 x="381.24359"
-                 id="tspan5159"
-                 sodipodi:role="line">50</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="29.068539"
-               id="text5161"
+               y="141.87543"
+               id="text5145"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan5163"
+                 id="tspan5147"
                  x="593.11237"
-                 y="29.068539"
+                 y="141.87543"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">40</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="29.0686"
+               id="text5157"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan5159"
+                 x="381.24359"
+                 y="29.0686"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">50</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="-83.738533"
-               id="text5173"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan5175"
-                 x="381.24359"
-                 y="-83.738533"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">60</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text5177"
-               y="-83.738342"
+               id="text5161"
+               y="29.068539"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="-83.738342"
+                 y="29.068539"
                  x="593.11237"
-                 id="tspan5179"
+                 id="tspan5163"
+                 sodipodi:role="line">50</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text5173"
+               y="-83.738533"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="-83.738533"
+                 x="381.24359"
+                 id="tspan5175"
                  sodipodi:role="line">60</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text5189"
-               y="-196.54565"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="-196.54565"
-                 x="381.24359"
-                 id="tspan5191"
-                 sodipodi:role="line">70</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="-196.54523"
-               id="text5193"
+               y="-83.738342"
+               id="text5177"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan5195"
+                 id="tspan5179"
                  x="593.11237"
-                 y="-196.54523"
+                 y="-83.738342"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">60</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="-196.54565"
+               id="text5189"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan5191"
+                 x="381.24359"
+                 y="-196.54565"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">70</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="-309.35278"
-               id="text5205"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan5207"
-                 x="381.24359"
-                 y="-309.35278"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">80</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text5209"
-               y="-309.35211"
+               id="text5193"
+               y="-196.54523"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="-309.35211"
+                 y="-196.54523"
                  x="593.11237"
-                 id="tspan5211"
+                 id="tspan5195"
+                 sodipodi:role="line">70</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text5205"
+               y="-309.35278"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="-309.35278"
+                 x="381.24359"
+                 id="tspan5207"
                  sodipodi:role="line">80</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text5221"
-               y="-422.15991"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="-422.15991"
-                 x="381.24359"
-                 id="tspan5223"
-                 sodipodi:role="line">90</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="-422.159"
-               id="text5225"
+               y="-309.35211"
+               id="text5209"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan5227"
+                 id="tspan5211"
                  x="593.11237"
-                 y="-422.159"
+                 y="-309.35211"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">80</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="-422.15991"
+               id="text5221"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan5223"
+                 x="381.24359"
+                 y="-422.15991"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">90</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383069,1.0484041)"
+               id="text5225"
+               y="-422.159"
+               x="593.11237"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="-422.159"
+                 x="593.11237"
+                 id="tspan5227"
+                 sodipodi:role="line">90</tspan></text>
           </g>
           <g
-             inkscape:label="#g4661"
-             id="AI_ground_num">
-            <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="705.91138"
-               id="text4513"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan4515"
-                 x="381.24359"
-                 y="705.91138"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">10</tspan></text>
+             id="AI_ground_num"
+             inkscape:label="#g4661">
             <text
                inkscape:label="#text975"
-               transform="scale(0.9538307,1.0484041)"
-               id="text4517"
-               y="705.90985"
-               x="593.11237"
+               transform="scale(0.95383277,1.0484018)"
+               id="text4513"
+               y="705.91138"
+               x="381.24359"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="705.90985"
-                 x="593.11237"
-                 id="tspan4519"
+                 y="705.91138"
+                 x="381.24359"
+                 id="tspan4515"
                  sodipodi:role="line">10</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text4541"
-               y="818.71851"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="818.71851"
-                 x="381.24359"
-                 id="tspan4543"
-                 sodipodi:role="line">20</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="818.71674"
-               id="text4545"
-               transform="scale(0.95383069,1.0484041)"
+               y="705.90985"
+               id="text4517"
+               transform="scale(0.9538307,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan4547"
+                 id="tspan4519"
                  x="593.11237"
-                 y="818.71674"
+                 y="705.90985"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">10</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="818.71851"
+               id="text4541"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan4543"
+                 x="381.24359"
+                 y="818.71851"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">20</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="931.52563"
-               id="text4549"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan4551"
-                 x="381.24359"
-                 y="931.52563"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">30</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text4553"
-               y="931.52362"
+               id="text4545"
+               y="818.71674"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="931.52362"
+                 y="818.71674"
                  x="593.11237"
-                 id="tspan4555"
+                 id="tspan4547"
+                 sodipodi:role="line">20</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text4549"
+               y="931.52563"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="931.52563"
+                 x="381.24359"
+                 id="tspan4551"
                  sodipodi:role="line">30</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text4581"
-               y="1044.3328"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1044.3328"
-                 x="381.24359"
-                 id="tspan4583"
-                 sodipodi:role="line">40</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="1044.3304"
-               id="text4585"
+               y="931.52362"
+               id="text4553"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan4587"
+                 id="tspan4555"
                  x="593.11237"
-                 y="1044.3304"
+                 y="931.52362"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">30</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="1044.3328"
+               id="text4581"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan4583"
+                 x="381.24359"
+                 y="1044.3328"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">40</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="1157.1399"
-               id="text4589"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan4591"
-                 x="381.24359"
-                 y="1157.1399"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">50</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text4593"
-               y="1157.1373"
+               id="text4585"
+               y="1044.3304"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1157.1373"
+                 y="1044.3304"
                  x="593.11237"
-                 id="tspan4595"
+                 id="tspan4587"
+                 sodipodi:role="line">40</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text4589"
+               y="1157.1399"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="1157.1399"
+                 x="381.24359"
+                 id="tspan4591"
                  sodipodi:role="line">50</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text4613"
-               y="1269.947"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1269.947"
-                 x="381.24359"
-                 id="tspan4615"
-                 sodipodi:role="line">60</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="1269.9442"
-               id="text4617"
+               y="1157.1373"
+               id="text4593"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan4619"
+                 id="tspan4595"
                  x="593.11237"
-                 y="1269.9442"
+                 y="1157.1373"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">50</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="1269.947"
+               id="text4613"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan4615"
+                 x="381.24359"
+                 y="1269.947"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">60</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="1382.7542"
-               id="text4621"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan4623"
-                 x="381.24359"
-                 y="1382.7542"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">70</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text4625"
-               y="1382.7511"
+               id="text4617"
+               y="1269.9442"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1382.7511"
+                 y="1269.9442"
                  x="593.11237"
-                 id="tspan4627"
+                 id="tspan4619"
+                 sodipodi:role="line">60</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text4621"
+               y="1382.7542"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="1382.7542"
+                 x="381.24359"
+                 id="tspan4623"
                  sodipodi:role="line">70</tspan></text>
             <text
-               inkscape:label="#text975"
-               transform="scale(0.95383277,1.0484018)"
-               id="text4645"
-               y="1495.5613"
-               x="381.24359"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1495.5613"
-                 x="381.24359"
-                 id="tspan4647"
-                 sodipodi:role="line">80</tspan></text>
-            <text
                xml:space="preserve"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                x="593.11237"
-               y="1495.558"
-               id="text4649"
+               y="1382.7511"
+               id="text4625"
                transform="scale(0.95383069,1.0484041)"
                inkscape:label="#text975"><tspan
                  sodipodi:role="line"
-                 id="tspan4651"
+                 id="tspan4627"
                  x="593.11237"
-                 y="1495.558"
+                 y="1382.7511"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">70</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="381.24359"
+               y="1495.5613"
+               id="text4645"
+               transform="scale(0.95383277,1.0484018)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan4647"
+                 x="381.24359"
+                 y="1495.5613"
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">80</tspan></text>
             <text
-               xml:space="preserve"
-               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-               x="381.24359"
-               y="1608.3684"
-               id="text4653"
-               transform="scale(0.95383277,1.0484018)"
-               inkscape:label="#text975"><tspan
-                 sodipodi:role="line"
-                 id="tspan4655"
-                 x="381.24359"
-                 y="1608.3684"
-                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">90</tspan></text>
-            <text
                inkscape:label="#text975"
                transform="scale(0.95383069,1.0484041)"
-               id="text4657"
-               y="1608.3649"
+               id="text4649"
+               y="1495.558"
                x="593.11237"
                style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
                xml:space="preserve"><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-                 y="1608.3649"
+                 y="1495.558"
                  x="593.11237"
-                 id="tspan4659"
+                 id="tspan4651"
+                 sodipodi:role="line">80</tspan></text>
+            <text
+               inkscape:label="#text975"
+               transform="scale(0.95383277,1.0484018)"
+               id="text4653"
+               y="1608.3684"
+               x="381.24359"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               xml:space="preserve"><tspan
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+                 y="1608.3684"
+                 x="381.24359"
+                 id="tspan4655"
                  sodipodi:role="line">90</tspan></text>
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+               x="593.11237"
+               y="1608.3649"
+               id="text4657"
+               transform="scale(0.95383069,1.0484041)"
+               inkscape:label="#text975"><tspan
+                 sodipodi:role="line"
+                 id="tspan4659"
+                 x="593.11237"
+                 y="1608.3649"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">90</tspan></text>
           </g>
         </g>
       </g>
       <g
-         transform="translate(0,97.082371)"
+         id="AI_pitch_lim"
          inkscape:label="#g5009"
-         id="AI_pitch_lim">
+         transform="translate(0,97.082371)">
         <g
            id="g4938">
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+             d="m 370.5312,154.3476 21.6616,0"
              id="path4906"
-             d="m 370.5312,154.3476 21.6616,0"
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 370.53103,162.42242 21.66136,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4909"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 370.53103,162.42242 21.66136,0"
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         </g>
         <g
-           id="g4951"
-           transform="translate(133.78495,0)">
+           transform="translate(133.78495,0)"
+           id="g4951">
           <path
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 370.5312,154.3476 21.6616,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4954"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 370.5312,154.3476 21.6616,0"
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+             d="m 370.53103,162.42242 21.66136,0"
              id="path4956"
-             d="m 370.53103,162.42242 21.66136,0"
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
         </g>
         <g
-           id="g4964"
-           transform="matrix(0.9999956,0,0,0.9999865,26.97857,532.2047)">
+           transform="matrix(0.9999956,0,0,0.9999865,26.97857,532.2047)"
+           id="g4964">
           <path
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-             d="m 370.5312,154.3476 21.6616,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path4966"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
-          <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4968"
-             d="m 370.53103,162.42242 21.66136,0"
-             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        </g>
-        <g
-           transform="matrix(0.9999956,0,0,0.9999865,106.81217,532.2047)"
-           id="g4989">
-          <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path4991"
              d="m 370.5312,154.3476 21.6616,0"
              style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
           <path
              style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
              d="m 370.53103,162.42242 21.66136,0"
-             id="path4993"
+             id="path4968"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
+        </g>
+        <g
+           id="g4989"
+           transform="matrix(0.9999956,0,0,0.9999865,106.81217,532.2047)">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+             d="m 370.5312,154.3476 21.6616,0"
+             id="path4991"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path4993"
+             d="m 370.53103,162.42242 21.66136,0"
+             style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         </g>
       </g>
       <g
-         transform="translate(0,97.08285)"
+         id="AI_pitch_lim_X"
          inkscape:label="#g4999"
-         id="AI_pitch_lim_X">
-        <text
-           transform="scale(0.97051544,1.0303803)"
-           inkscape:label="#text4314"
-           id="text4924"
-           y="164.03458"
-           x="392.94058"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1"
-             y="164.03458"
-             x="392.94058"
-             id="tspan4926"
-             sodipodi:role="line">X</tspan></text>
+         transform="translate(0,97.08285)">
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="530.78998"
+           x="392.94058"
            y="164.03458"
-           id="text4958"
+           id="text4924"
            inkscape:label="#text4314"
            transform="scale(0.97051544,1.0303803)"><tspan
              sodipodi:role="line"
-             id="tspan4960"
-             x="530.78998"
+             id="tspan4926"
+             x="392.94058"
              y="164.03458"
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1">X</tspan></text>
         <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="420.73514"
-           y="680.54834"
-           id="text4970"
+           transform="scale(0.97051544,1.0303803)"
            inkscape:label="#text4314"
-           transform="scale(0.97051987,1.0303756)"><tspan
-             sodipodi:role="line"
-             id="tspan4972"
-             x="420.73514"
-             y="680.54834"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1">X</tspan></text>
+           id="text4958"
+           y="164.03458"
+           x="530.78998"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1"
+             y="164.03458"
+             x="530.78998"
+             id="tspan4960"
+             sodipodi:role="line">X</tspan></text>
         <text
            transform="scale(0.97051987,1.0303756)"
            inkscape:label="#text4314"
-           id="text4995"
+           id="text4970"
            y="680.54834"
-           x="502.99374"
+           x="420.73514"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1"
              y="680.54834"
-             x="502.99374"
-             id="tspan4997"
+             x="420.73514"
+             id="tspan4972"
              sodipodi:role="line">X</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="502.99374"
+           y="680.54834"
+           id="text4995"
+           inkscape:label="#text4314"
+           transform="scale(0.97051987,1.0303756)"><tspan
+             sodipodi:role="line"
+             id="tspan4997"
+             x="502.99374"
+             y="680.54834"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1">X</tspan></text>
       </g>
     </g>
     <g
-       id="AI_horizon_ground"
+       inkscape:label="#g4918"
        transform="translate(0,-97.082454)"
-       inkscape:label="#g4918">
+       id="AI_horizon_ground">
       <rect
-         style="opacity:1;fill:#522001;fill-opacity:1;stroke:none;stroke-width:2.48752213;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect4914"
-         width="1287.3097"
-         height="1102.3192"
-         x="-195.3976"
+         inkscape:label="#rect5809"
          y="611.74884"
+         x="-195.3976"
+         height="1102.3192"
+         width="1287.3097"
+         id="rect4914"
+         style="opacity:1;fill:#522001;fill-opacity:1;stroke:none;stroke-width:2.48752213;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -193.7976,610.26868 1284.1095,0"
+         id="path4916"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="AI_heading"
+       inkscape:label="#g4743"
+       transform="translate(-153.56239,-430.12536)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4712"
+         d="m 306.19037,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 404.73197,944.75532 0,12.35406"
+         id="path4732"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4734"
+         d="m 503.27357,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 601.81517,944.75532 0,12.35406"
+         id="path4736"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4746"
+         d="m 700.35638,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 798.89798,944.75532 0,12.35406"
+         id="path4754"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4756"
+         d="m 897.43958,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    </g>
+    <g
+       transform="translate(0,-206.0288)"
+       inkscape:label="#g4606"
+       id="AI_horizon_sky">
+      <rect
+         style="opacity:1;fill:#368acd;fill-opacity:1;stroke:none;stroke-width:2.58921981;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4600"
+         width="1287.3096"
+         height="102.31912"
+         x="-195.39726"
+         y="409.34946"
          inkscape:label="#rect5809" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path4916"
-         d="m -193.7976,610.26868 1284.1095,0"
+         id="path4665"
+         d="m -193.7976,513.1864 1284.1095,0"
          style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     </g>
-    <g
-       transform="translate(-153.56239,-430.12536)"
-       inkscape:label="#g4743"
-       id="AI_heading">
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 306.19037,944.75532 0,12.35406"
-         id="path4712"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4732"
-         d="m 404.73197,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 503.27357,944.75532 0,12.35406"
-         id="path4734"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4736"
-         d="m 601.81517,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 700.35638,944.75532 0,12.35406"
-         id="path4746"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4754"
-         d="m 798.89798,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 897.43958,944.75532 0,12.35406"
-         id="path4756"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-    </g>
-    <g
-       id="AI_horizon_sky"
-       inkscape:label="#g4606"
-       transform="translate(0,-206.0288)">
-      <rect
-         inkscape:label="#rect5809"
-         y="409.34946"
-         x="-195.39726"
-         height="102.31912"
-         width="1287.3096"
-         id="rect4600"
-         style="opacity:1;fill:#368acd;fill-opacity:1;stroke:none;stroke-width:2.58921981;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m -193.7976,513.1864 1284.1095,0"
-         id="path4665"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-    </g>
     <path
-       inkscape:connector-curvature="0"
-       id="AI_horizon_mask"
-       d="m 452.95372,819.65041 -266.35567,0 0,-303.78402 0,-303.78402 266.35567,0 266.35567,0 0,303.78402 0,303.78402 z m -4.70012,-29.15978 22.4688,-0.86543 22.7656,-2.8912 c 9.03456,-1.14738 22.22459,-4.4067 31.0728,-6.6408 8.84823,-2.23412 21.63139,-7.28853 28.8248,-9.9304 7.19343,-2.64188 17.79374,-8.25496 25.9288,-12.3008 8.13505,-4.04583 20.89048,-11.8465 29.1968,-18.024 l 17.7128,-13.1728 14.076,-13.236 12.9,-13.496 10.2808,-11.2776 10.1272,-13.148 8.5,-11.9752 8.23219,-13.516 0,-137.35577 0,-136.5069 -8.23219,-13.516 c -2.4515,-4.02499 -5.60322,-7.65441 -8.5,-11.9752 -2.68932,-4.01133 -7.74317,-10.50003 -10.1272,-13.148 l -10.2808,-11.2776 -12.9,-13.496 -14.076,-13.236 -17.7128,-13.1728 c -8.4714,-6.30008 -21.06175,-13.97818 -29.1968,-18.024 -8.13506,-4.04584 -18.73537,-9.65931 -25.9288,-12.3012 -7.19341,-2.64188 -28.8248,-9.9312 -28.8248,-9.9312 0,0 -28.6997,-6.20989 -31.0728,-6.6408 l -22.7656,-2.8912 c 0,0 -13.87507,-0.84398 -22.4688,-0.8644 -9.15881,-0.0218 -22.4688,0.8644 -22.4688,0.8644 l -22.7656,2.8912 c -9.03456,1.14737 -22.22457,4.4067 -31.0728,6.6408 -8.84823,2.2341 -21.63138,7.28932 -28.8248,9.9312 -7.19343,2.64189 -17.79373,8.25536 -25.9288,12.3012 -8.13504,4.04582 -21.07541,12.04906 -29.1968,18.024 l -17.7128,13.1728 -14.076,13.236 -12.9,13.496 -10.2808,11.2776 -10.1272,13.148 -8.5,11.9752 -8.48835,13.516 0,136.5069 3.5e-4,137.35577 8.488,13.516 8.5,11.9752 10.1272,13.148 10.2808,11.2776 12.9,13.496 14.076,13.236 17.7128,13.1728 c 8.09045,6.01677 21.06176,13.97818 29.1968,18.024 8.13507,4.04585 18.73537,9.65892 25.9288,12.3008 7.19342,2.64188 19.83464,7.66085 28.8248,9.9308 8.99013,2.26993 23.06292,5.6237 31.0728,6.6408 l 22.7656,2.8912 22.4688,0.8652 z"
-       style="fill:#000000"
+       sodipodi:nodetypes="cccccccccccssssscccccccccssscccssscccscssssscccccccccccccccsssssccc"
        inkscape:label="#path4862"
-       sodipodi:nodetypes="cccccccccccssssscccccccccssscccssscccscssssscccccccccccccccsssssccc" />
+       style="fill:#000000"
+       d="m 452.95372,819.65041 -266.35567,0 0,-303.78402 0,-303.78402 266.35567,0 266.35567,0 0,303.78402 0,303.78402 z m -4.70012,-29.15978 22.4688,-0.86543 22.7656,-2.8912 c 9.03456,-1.14738 22.22459,-4.4067 31.0728,-6.6408 8.84823,-2.23412 21.63139,-7.28853 28.8248,-9.9304 7.19343,-2.64188 17.79374,-8.25496 25.9288,-12.3008 8.13505,-4.04583 20.89048,-11.8465 29.1968,-18.024 l 17.7128,-13.1728 14.076,-13.236 12.9,-13.496 10.2808,-11.2776 10.1272,-13.148 8.5,-11.9752 8.23219,-13.516 0,-137.35577 0,-136.5069 -8.23219,-13.516 c -2.4515,-4.02499 -5.60322,-7.65441 -8.5,-11.9752 -2.68932,-4.01133 -7.74317,-10.50003 -10.1272,-13.148 l -10.2808,-11.2776 -12.9,-13.496 -14.076,-13.236 -17.7128,-13.1728 c -8.4714,-6.30008 -21.06175,-13.97818 -29.1968,-18.024 -8.13506,-4.04584 -18.73537,-9.65931 -25.9288,-12.3012 -7.19341,-2.64188 -28.8248,-9.9312 -28.8248,-9.9312 0,0 -28.6997,-6.20989 -31.0728,-6.6408 l -22.7656,-2.8912 c 0,0 -13.87507,-0.84398 -22.4688,-0.8644 -9.15881,-0.0218 -22.4688,0.8644 -22.4688,0.8644 l -22.7656,2.8912 c -9.03456,1.14737 -22.22457,4.4067 -31.0728,6.6408 -8.84823,2.2341 -21.63138,7.28932 -28.8248,9.9312 -7.19343,2.64189 -17.79373,8.25536 -25.9288,12.3012 -8.13504,4.04582 -21.07541,12.04906 -29.1968,18.024 l -17.7128,13.1728 -14.076,13.236 -12.9,13.496 -10.2808,11.2776 -10.1272,13.148 -8.5,11.9752 -8.48835,13.516 0,136.5069 3.5e-4,137.35577 8.488,13.516 8.5,11.9752 10.1272,13.148 10.2808,11.2776 12.9,13.496 14.076,13.236 17.7128,13.1728 c 8.09045,6.01677 21.06176,13.97818 29.1968,18.024 8.13507,4.04585 18.73537,9.65892 25.9288,12.3008 7.19342,2.64188 19.83464,7.66085 28.8248,9.9308 8.99013,2.26993 23.06292,5.6237 31.0728,6.6408 l 22.7656,2.8912 22.4688,0.8652 z"
+       id="AI_horizon_mask"
+       inkscape:connector-curvature="0" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 433.21105,207.78584 30.0845,1e-5 -15.04195,25.28563 z"
-       id="AI_bankindex"
-       inkscape:connector-curvature="0"
+       inkscape:label="#rect902"
        sodipodi:nodetypes="cccc"
-       inkscape:label="#rect902" />
+       inkscape:connector-curvature="0"
+       id="AI_bankindex"
+       d="m 433.21105,207.78584 30.0845,1e-5 -15.04195,25.28563 z"
+       style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <rect
-       y="506.77753"
-       x="442.1286"
-       height="12.775722"
-       width="12.257594"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73024487;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4756"
-       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.73024487;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <rect
-       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:2.87749815;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="FD_roll"
-       width="7.5999999"
-       height="263.53088"
-       x="444.45679"
-       y="381.39041"
-       inkscape:label="#rect4743" />
+       width="12.257594"
+       height="12.775722"
+       x="442.1286"
+       y="506.77753" />
     <rect
        inkscape:label="#rect4743"
-       y="-580.02087"
-       x="509.36719"
-       height="263.53848"
+       y="381.39041"
+       x="444.45679"
+       height="263.53088"
        width="7.5999999"
-       id="FD_pitch"
+       id="FD_roll"
+       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:2.87749815;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       transform="matrix(0,1,-1,0,0,0)"
        style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:2.87749815;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0,1,-1,0,0,0)" />
+       id="FD_pitch"
+       width="7.5999999"
+       height="263.53848"
+       x="509.36719"
+       y="-580.02087"
+       inkscape:label="#rect4743" />
     <g
-       id="AI_stick_pos"
+       transform="translate(-0.38165298,0)"
        inkscape:label="#g4824"
-       transform="translate(-0.38165298,0)">
+       id="AI_stick_pos">
       <g
          id="g4802">
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 452.50015,509.31081 29.04648,0"
            id="path4776"
-           d="m 452.50015,509.31081 29.04648,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 452.49998,480.26394 0,29.04648"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path4800"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 452.49998,480.26394 0,29.04648"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
       <g
-         transform="matrix(-1,0,0,1,897.27706,0)"
-         id="g4806">
+         id="g4806"
+         transform="matrix(-1,0,0,1,897.27706,0)">
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 452.50015,509.31081 29.04648,0"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path4808"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 452.50015,509.31081 29.04648,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 452.49998,480.26394 0,29.04648"
            id="path4810"
-           d="m 452.49998,480.26394 0,29.04648"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
       </g>
       <g
-         transform="matrix(1,0,0,-1,0,1026.344)"
-         id="g4812">
+         id="g4812"
+         transform="matrix(1,0,0,-1,0,1026.344)">
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 452.50015,509.31081 29.04648,0"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path4814"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4816"
-           d="m 452.49998,480.26394 0,29.04648"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      </g>
-      <g
-         id="g4818"
-         transform="matrix(-1,0,0,-1,897.27706,1026.344)">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4820"
            d="m 452.50015,509.31081 29.04648,0"
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         <path
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
            d="m 452.49998,480.26394 0,29.04648"
-           id="path4822"
+           id="path4816"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,-1,897.27706,1026.344)"
+         id="g4818">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 452.50015,509.31081 29.04648,0"
+           id="path4820"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4822"
+           d="m 452.49998,480.26394 0,29.04648"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
     </g>
     <rect
-       style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.77994585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="AI_center"
-       width="15.997281"
-       height="16.491779"
-       x="440.25876"
+       inkscape:label="#rect4741"
        y="504.91953"
-       inkscape:label="#rect4741" />
+       x="440.25876"
+       height="16.491779"
+       width="15.997281"
+       id="AI_center"
+       style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.77994585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       id="g4844"
-       transform="matrix(1.0666667,0,0,1.066636,4.919636,-0.50381959)">
+       transform="matrix(1.0666667,0,0,1.066636,4.919636,-0.50381959)"
+       id="g4844">
+      <rect
+         y="475.02829"
+         x="204.88916"
+         height="12.915084"
+         width="93.804001"
+         id="rect4756-1"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:8.10005665;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.3055582;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4839"
+         width="12.428999"
+         height="27.540085"
+         x="286.12354"
+         y="486.37204" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375005;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 279.39676,473.84829 20.67975,-1.3e-4 0,15.43882 0,0 1.8e-4,25.65723 -15.4389,0 -0.14628,-25.65723 0,0 -81.2588,-5e-5 0,-15.43891 76.16405,2.1e-4 z"
+         id="rect4760-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc" />
+    </g>
+    <g
+       transform="matrix(-1.0666667,0,0,1.066636,891.59023,-0.50381959)"
+       id="g4856">
       <rect
          style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:8.10005665;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4756-1"
+         id="rect4850"
          width="93.804001"
          height="12.915084"
          x="204.88916"
@@ -1391,630 +1415,520 @@
          x="286.12354"
          height="27.540085"
          width="12.428999"
-         id="rect4839"
+         id="rect4852"
          style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.3055582;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccccccccc"
          inkscape:connector-curvature="0"
-         id="rect4760-1"
+         id="path4854"
          d="m 279.39676,473.84829 20.67975,-1.3e-4 0,15.43882 0,0 1.8e-4,25.65723 -15.4389,0 -0.14628,-25.65723 0,0 -81.2588,-5e-5 0,-15.43891 76.16405,2.1e-4 z"
          style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375005;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
-    <g
-       id="g4856"
-       transform="matrix(-1.0666667,0,0,1.066636,891.59023,-0.50381959)">
-      <rect
-         y="475.02829"
-         x="204.88916"
-         height="12.915084"
-         width="93.804001"
-         id="rect4850"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:8.10005665;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.3055582;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4852"
-         width="12.428999"
-         height="27.540085"
-         x="286.12354"
-         y="486.37204" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375005;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 279.39676,473.84829 20.67975,-1.3e-4 0,15.43882 0,0 1.8e-4,25.65723 -15.4389,0 -0.14628,-25.65723 0,0 -81.2588,-5e-5 0,-15.43891 76.16405,2.1e-4 z"
-         id="path4854"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccc" />
-    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="rect888"
+       d="m 233.14953,298.28185 17.53625,17.53574"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 233.14953,298.28185 17.53625,17.53574"
-       id="rect888"
+       d="m 663.61529,298.28185 -17.53626,17.53574"
+       id="path892"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path892"
-       d="m 663.61529,298.28185 -17.53626,17.53574"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 302.91873,276.44572 c 89.26696,-54.70986 201.68233,-54.70986 290.94929,0"
        id="path894"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 302.91873,276.44572 c 89.26696,-54.70986 201.68233,-54.70986 290.94929,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <g
-       id="AI_bank"
+       inkscape:transform-center-y="-246.1722"
        inkscape:label="#g4313"
-       inkscape:transform-center-y="-246.1722">
+       id="AI_bank">
       <path
-         inkscape:transform-center-y="-258.88333"
-         inkscape:label="#path905"
-         style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:3.99994254;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 433.21105,267.08957 30.0845,-10e-6 -15.04225,-25.28563 z"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
          id="AI_bankt"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
+         d="m 433.21105,267.08957 30.0845,-10e-6 -15.04225,-25.28563 z"
+         style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:3.99994254;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         inkscape:label="#path905"
+         inkscape:transform-center-y="-258.88333" />
       <path
-         inkscape:transform-center-y="-228.40743"
-         inkscape:label="#path912"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="AI_slipskid"
+         style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:3.99994254;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="m 418.32961,292.18309 59.8472,-3e-5 -8.6432,-14.52797 -42.5608,0 z"
-         style="fill:none;fill-opacity:1;stroke:#c9cc15;stroke-width:3.99994254;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="AI_slipskid"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         inkscape:label="#path912"
+         inkscape:transform-center-y="-228.40743" />
     </g>
     <g
        id="g3944">
       <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 288.584,252.95092 12.66714,20.76999"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
          id="path4363"
+         d="m 288.584,252.95092 12.66714,20.76999"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 302.4256,244.9824 11.6333,21.34883"
+         id="path4365"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
       <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4365"
-         d="m 302.4256,244.9824 11.6333,21.34883"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4367"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="m 288.584,252.95092 13.8416,-7.96852"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="path4367"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
     </g>
     <g
        id="g3962">
       <g
          id="g3949">
         <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 340.35189,239.5184 5.62182,14.20878"
+           id="path3932"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
            sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           id="path3932"
-           d="m 340.35189,239.5184 5.62182,14.20878"
+           id="path3934"
+           d="m 354.9152,234.0368 4.87069,14.48383"
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         <path
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 354.9152,234.0368 4.87069,14.48383"
-           id="path3934"
+           d="m 354.9152,234.0368 -14.5632,5.4816"
+           id="path3936"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path3936"
-           d="m 354.9152,234.0368 -14.5632,5.4816"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
     </g>
     <g
-       id="g4374"
-       transform="matrix(-1,0,0,1,896.78566,0)">
+       transform="matrix(-1,0,0,1,896.78566,0)"
+       id="g4374">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 288.584,252.95092 12.66714,20.76999"
+         id="path4376"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path4376"
-         d="m 288.584,252.95092 12.66714,20.76999"
+         id="path4378"
+         d="m 302.4256,244.9824 11.6333,21.34883"
          style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 302.4256,244.9824 11.6333,21.34883"
-         id="path4378"
+         sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 288.584,252.95092 13.8416,-7.96852"
          id="path4380"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
+         d="m 288.584,252.95092 13.8416,-7.96852"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     </g>
     <g
-       id="AI_bank_lim"
+       transform="translate(0,0.59999999)"
        inkscape:label="#g4750"
-       transform="translate(0,0.59999999)">
+       id="AI_bank_lim">
       <g
-         transform="translate(0,19.596045)"
-         id="g4545">
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4382"
-           d="m 189.57505,376.22489 14.1363,6.6882"
-           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="g4545"
+         transform="translate(0,19.596045)">
         <path
            style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 189.46264,389.81135 14.36112,6.19076"
-           id="path4384"
+           d="m 189.57505,376.22489 14.1363,6.6882"
+           id="path4382"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
-      </g>
-      <g
-         transform="matrix(-1,0,0,1,896.51521,20.196045)"
-         id="g4876">
         <path
            sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           id="path4878"
-           d="m 189.57505,376.22489 14.1363,6.6882"
-           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           id="path4384"
            d="m 189.46264,389.81135 14.36112,6.19076"
-           id="path4880"
+           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      </g>
+      <g
+         id="g4876"
+         transform="matrix(-1,0,0,1,896.51521,20.196045)">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 189.57505,376.22489 14.1363,6.6882"
+           id="path4878"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4880"
+           d="m 189.46264,389.81135 14.36112,6.19076"
+           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
     </g>
     <g
-       inkscape:label="#g4886"
-       id="AI_bank_lim_X">
+       id="AI_bank_lim_X"
+       inkscape:label="#g4886">
       <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="202.60973"
-         y="404.63544"
+         transform="scale(0.97051454,1.0303813)"
+         inkscape:label="#text4314"
          id="text4314"
-         inkscape:label="#text4314"
-         transform="scale(0.97051454,1.0303813)"><tspan
-           sodipodi:role="line"
-           id="tspan4407"
-           x="202.60973"
-           y="404.63544"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1">X</tspan></text>
-      <text
-         transform="scale(0.97051452,1.0303813)"
-         inkscape:label="#text4314"
-         id="text4882"
          y="404.63544"
-         x="721.12775"
+         x="202.60973"
          style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          xml:space="preserve"><tspan
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1"
            y="404.63544"
-           x="721.12775"
-           id="tspan4884"
+           x="202.60973"
+           id="tspan4407"
            sodipodi:role="line">X</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="721.12775"
+         y="404.63544"
+         id="text4882"
+         inkscape:label="#text4314"
+         transform="scale(0.97051452,1.0303813)"><tspan
+           sodipodi:role="line"
+           id="tspan4884"
+           x="721.12775"
+           y="404.63544"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#bb6100;fill-opacity:1">X</tspan></text>
     </g>
     <g
-       id="g3954"
-       transform="matrix(-1,0,0,1,896.72324,0)">
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path3956"
-         d="m 340.35189,239.5184 5.62182,14.20878"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       transform="matrix(-1,0,0,1,896.72324,0)"
+       id="g3954">
       <path
          style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 354.9152,234.0368 4.87069,14.48383"
-         id="path3958"
+         d="m 340.35189,239.5184 5.62182,14.20878"
+         id="path3956"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path3960"
-         d="m 354.9152,234.0368 -14.5632,5.4816"
+         id="path3958"
+         d="m 354.9152,234.0368 4.87069,14.48383"
          style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 354.9152,234.0368 -14.5632,5.4816"
+         id="path3960"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
     </g>
     <g
-       id="g3968"
-       transform="matrix(0.98404072,0.17794355,-0.17794355,0.98404072,97.433196,-71.336811)">
+       transform="matrix(0.98404072,0.17794355,-0.17794355,0.98404072,97.433196,-71.336811)"
+       id="g3968">
       <g
          id="g3970">
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 340.35189,239.5184 5.62182,14.20878"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path3972"
+           d="m 340.35189,239.5184 5.62182,14.20878"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 354.9152,234.0368 4.87069,14.48383"
+           id="path3974"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
         <path
            sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           id="path3974"
-           d="m 354.9152,234.0368 4.87069,14.48383"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 354.9152,234.0368 -14.5632,5.4816"
            id="path3976"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 354.9152,234.0368 -14.5632,5.4816"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
     </g>
     <g
-       transform="matrix(-0.98404072,0.17794355,0.17794355,0.98404072,799.64735,-71.336811)"
-       id="g3978">
+       id="g3978"
+       transform="matrix(-0.98404072,0.17794355,0.17794355,0.98404072,799.64735,-71.336811)">
       <g
          id="g3980">
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path3982"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
            d="m 340.35189,239.5184 5.62182,14.20878"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+           id="path3982"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 354.9152,234.0368 4.87069,14.48383"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path3984"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 354.9152,234.0368 4.87069,14.48383"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path3986"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
            d="m 354.9152,234.0368 -14.5632,5.4816"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+           id="path3986"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
       </g>
     </g>
     <g
-       id="AI_agl_g"
-       inkscape:transform-center-y="245.55742"
+       transform="translate(0,-1.4)"
        inkscape:label="#g4612"
-       transform="translate(0,-1.4)">
+       inkscape:transform-center-y="245.55742"
+       id="AI_agl_g">
       <text
-         inkscape:transform-center-y="245.55937"
-         inkscape:label="#text983"
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         x="511.25748"
-         y="680.72845"
+         transform="scale(0.87678236,1.1405339)"
          id="AI_agl"
-         transform="scale(0.87678236,1.1405339)"><tspan
-           sodipodi:role="line"
-           id="tspan4624"
-           x="511.25748"
+         y="680.72845"
+         x="511.25748"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         xml:space="preserve"
+         inkscape:label="#text983"
+         inkscape:transform-center-y="245.55937"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:45px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577"
            y="680.72845"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:45px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">0000</tspan></text>
+           x="511.25748"
+           id="tspan4624"
+           sodipodi:role="line">0000</tspan></text>
     </g>
     <g
-       id="AI_stick"
+       transform="translate(2.8403413,1.952603)"
        inkscape:label="#g4714"
-       transform="translate(2.8403413,1.952603)">
+       id="AI_stick">
       <g
-         transform="translate(0.97071068,0)"
-         id="g4630">
+         id="g4630"
+         transform="translate(0.97071068,0)">
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 247.69915,662.50422 40.64303,0"
            id="path4624"
-           d="m 247.69915,662.50422 40.64303,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
         <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 247.6993,621.86099 0,40.64303"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path4628"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-      </g>
-      <g
-         id="g4634"
-         transform="matrix(-1,0,0,1,894.37964,0)">
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 252.22463,662.50422 40.64303,0"
-           id="path4636"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4638"
-           d="m 252.22478,621.86099 0,40.64303"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      </g>
-      <g
-         id="g4664"
-         transform="matrix(1,0,0,-1,0.97071068,1022.4297)">
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 247.69915,662.50422 40.64303,0"
-           id="path4666"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4668"
            d="m 247.6993,621.86099 0,40.64303"
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
       <g
-         transform="matrix(-1,0,0,-1,894.37964,1022.4297)"
-         id="g4670">
+         transform="matrix(-1,0,0,1,894.37964,0)"
+         id="g4634">
         <path
            sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           id="path4672"
+           id="path4636"
            d="m 252.22463,662.50422 40.64303,0"
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
         <path
            style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
            d="m 252.22478,621.86099 0,40.64303"
-           id="path4674"
+           id="path4638"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         transform="matrix(1,0,0,-1,0.97071068,1022.4297)"
+         id="g4664">
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4666"
+           d="m 247.69915,662.50422 40.64303,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 247.6993,621.86099 0,40.64303"
+           id="path4668"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         id="g4670"
+         transform="matrix(-1,0,0,-1,894.37964,1022.4297)">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 252.22463,662.50422 40.64303,0"
+           id="path4672"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4674"
+           d="m 252.22478,621.86099 0,40.64303"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
       </g>
     </g>
   </g>
   <rect
-     inkscape:label="#rect9211"
-     y="237.03366"
-     x="124.90075"
-     height="552.00073"
-     width="21.356052"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="ASI_max_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     width="21.356052"
+     height="552.00073"
+     x="124.90075"
+     y="237.03366"
+     inkscape:label="#rect9211" />
   <rect
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="ALT_target_clip"
+     inkscape:label="#rect9211"
+     y="237.03366"
+     x="752.0592"
+     height="552.00073"
      width="104.39759"
-     height="552.00073"
-     x="752.0592"
-     y="237.03366"
-     inkscape:label="#rect9211" />
+     id="ALT_target_clip"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
-     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="rect4416"
-     width="469.54089"
-     height="64.058205"
+     y="945.01337"
      x="213.5808"
-     y="945.01337" />
-  <rect
-     inkscape:label="#rect9211"
-     y="941.81519"
-     x="213.58055"
-     height="67.255974"
-     width="469.54053"
-     id="HDG_scale_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="HDG_target_clip"
-     width="603.362"
-     height="54.440548"
-     x="146.66983"
-     y="890.56866"
-     inkscape:label="#rect9211" />
-  <g
-     inkscape:label="#g4848"
-     id="HDG_frame">
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4422"
-       d="m 211.98006,943.4104 472.74554,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4418"
-       d="m 684.7256,943.51065 3.2e-4,64.06045"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 211.98006,943.41065 0,64.06045"
-       id="path4420"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-  </g>
-  <rect
-     inkscape:label="#rect9211"
-     y="237.03366"
-     x="752.0592"
-     height="552.00073"
-     width="106.37749"
-     id="ALT_scale_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     inkscape:label="#rect9211"
-     y="173.68726"
-     x="122.9302"
-     height="678.69348"
-     width="37.907772"
-     id="ASI_target_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     inkscape:label="#rect4351"
-     y="237.04375"
-     x="11.565234"
-     height="551.98004"
-     width="111.28601"
-     id="ASI_grey"
+     height="64.058205"
+     width="469.54089"
+     id="rect4416"
      style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <rect
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="ASI_scale_clip"
-     width="117.6912"
-     height="552.00073"
-     x="8.3655996"
-     y="237.03366"
+     id="HDG_scale_clip"
+     width="469.54053"
+     height="67.255974"
+     x="213.58055"
+     y="941.81519"
      inkscape:label="#rect9211" />
   <rect
      inkscape:label="#rect9211"
-     y="237.0336"
-     x="8.3655996"
-     height="275.79279"
-     width="117.6912"
-     id="ASI_trend_up_clip"
+     y="890.56866"
+     x="146.66983"
+     height="54.440548"
+     width="603.362"
+     id="HDG_target_clip"
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     inkscape:label="#VS_pointer_clip"
-     sodipodi:nodetypes="ccsccc"
-     inkscape:connector-curvature="0"
-     id="VS_pointer_clip"
-     d="m 975.91454,177.03888 47.58966,0 c -0.052,113.09539 0.026,226.19024 0,339.28612 -0.026,110.77565 -0.158,221.55229 0,332.33137 l -47.58966,0 z"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     sodipodi:nodetypes="ccccccc"
-     inkscape:connector-curvature="0"
-     id="rect5044"
-     d="m 952.19,178.46607 30.52166,-1.3e-4 31.97194,102.24587 0,464.27063 -31.97194,102.24587 -30.52166,1.5e-4 z"
-     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:4.17444229;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <g
-     inkscape:label="#g4759"
-     id="VS_group">
+     id="HDG_frame"
+     inkscape:label="#g4848">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 211.98006,943.4104 472.74554,0"
+       id="path4422"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 684.7256,943.51065 3.2e-4,64.06045"
+       id="path4418"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4420"
+       d="m 211.98006,943.41065 0,64.06045"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  </g>
+  <rect
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="ALT_scale_clip"
+     width="106.37749"
+     height="552.00073"
+     x="752.0592"
+     y="237.03366"
+     inkscape:label="#rect9211" />
+  <rect
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="ASI_target_clip"
+     width="37.907772"
+     height="678.69348"
+     x="122.9302"
+     y="173.68726"
+     inkscape:label="#rect9211" />
+  <rect
+     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     id="ASI_grey"
+     width="111.28601"
+     height="551.98004"
+     x="11.565234"
+     y="237.04375"
+     inkscape:label="#rect4351" />
+  <rect
+     inkscape:label="#rect9211"
+     y="237.03366"
+     x="8.3655996"
+     height="552.00073"
+     width="117.6912"
+     id="ASI_scale_clip"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="ASI_trend_up_clip"
+     width="117.6912"
+     height="275.79279"
+     x="8.3655996"
+     y="237.0336"
+     inkscape:label="#rect9211" />
+  <path
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 975.91454,177.03888 47.58966,0 c -0.052,113.09539 0.026,226.19024 0,339.28612 -0.026,110.77565 -0.158,221.55229 0,332.33137 l -47.58966,0 z"
+     id="VS_pointer_clip"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsccc"
+     inkscape:label="#VS_pointer_clip" />
+  <path
+     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:4.17444229;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 952.19,178.46607 30.52166,-1.3e-4 31.97194,102.24587 0,464.27063 -31.97194,102.24587 -30.52166,1.5e-4 z"
+     id="rect5044"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccc" />
+  <g
+     id="VS_group"
+     inkscape:label="#g4759">
     <g
-       id="g5112"
-       transform="matrix(1.0666667,0,0,1.066636,0.28284271,-0.50381959)">
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         x="1019.0017"
-         y="569.32635"
-         id="text5096"
-         transform="scale(0.87676975,1.1405503)"><tspan
-           sodipodi:role="line"
-           id="tspan5094"
-           x="1019.0017"
-           y="569.32635"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:29.7717px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">1</tspan></text>
+       transform="matrix(1.0666667,0,0,1.066636,0.28284271,-0.50381959)"
+       id="g5112">
       <text
          transform="scale(0.87676975,1.1405503)"
-         id="text5100"
-         y="628.34387"
+         id="text5096"
+         y="569.32635"
          x="1019.0017"
          style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
          xml:space="preserve"><tspan
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:29.7717px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-           y="628.34387"
+           y="569.32635"
            x="1019.0017"
-           id="tspan5098"
-           sodipodi:role="line">2</tspan></text>
+           id="tspan5094"
+           sodipodi:role="line">1</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
          x="1019.0017"
-         y="687.27924"
-         id="text5104"
+         y="628.34387"
+         id="text5100"
          transform="scale(0.87676975,1.1405503)"><tspan
            sodipodi:role="line"
-           id="tspan5102"
+           id="tspan5098"
            x="1019.0017"
+           y="628.34387"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:29.7717px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">2</tspan></text>
+      <text
+         transform="scale(0.87676975,1.1405503)"
+         id="text5104"
+         y="687.27924"
+         x="1019.0017"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:29.7717px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
            y="687.27924"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:29.7717px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">6</tspan></text>
-    </g>
-    <g
-       id="g5092"
-       transform="matrix(1.0666667,0,0,-1.066636,0.28284271,1026.1924)">
-      <rect
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5080"
-         width="9.9375"
-         height="3.4620874"
-         x="911.8125"
-         y="400.32764" />
-      <rect
-         y="287.02451"
-         x="911.8125"
-         height="3.4620874"
-         width="9.9375"
-         id="rect5082"
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5084"
-         width="9.9375"
-         height="6.4299178"
-         x="911.8125"
-         y="319.32944" />
-      <rect
-         y="251.79059"
-         x="911.8125"
-         height="6.4299178"
-         width="9.9375"
-         id="rect5086"
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5088"
-         width="9.9375"
-         height="3.4620874"
-         x="911.8125"
-         y="219.53999" />
-      <rect
-         y="184.36314"
-         x="912.28125"
-         height="6.4299173"
-         width="9.9375"
-         id="rect5090"
-         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g4317"
-       transform="translate(0.28284271,0)">
-      <text
-         transform="scale(0.87678236,1.1405339)"
-         id="text5130"
-         y="183.6866"
-         x="1086.9194"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-           y="183.6866"
-           x="1086.9194"
-           id="tspan5128"
+           x="1019.0017"
+           id="tspan5102"
            sodipodi:role="line">6</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         x="1086.9194"
-         y="246.63768"
-         id="text5134"
-         transform="scale(0.87678236,1.1405339)"><tspan
-           sodipodi:role="line"
-           id="tspan5132"
-           x="1086.9194"
-           y="246.63768"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">2</tspan></text>
-      <text
-         transform="scale(0.87678236,1.1405339)"
-         id="text5138"
-         y="309.50116"
-         x="1086.9194"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-           y="309.50116"
-           x="1086.9194"
-           id="tspan5136"
-           sodipodi:role="line">1</tspan></text>
     </g>
     <g
-       id="g5078"
-       transform="matrix(1.0666667,0,0,1.066636,0.28284271,-0.50381959)">
+       transform="matrix(1.0666667,0,0,-1.066636,0.28284271,1026.1924)"
+       id="g5092">
       <rect
          y="400.32764"
          x="911.8125"
          height="3.4620874"
          width="9.9375"
-         id="rect5047"
+         id="rect5080"
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5049"
+         id="rect5082"
          width="9.9375"
          height="3.4620874"
          x="911.8125"
@@ -2024,11 +1938,11 @@
          x="911.8125"
          height="6.4299178"
          width="9.9375"
-         id="rect5051"
+         id="rect5084"
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5053"
+         id="rect5086"
          width="9.9375"
          height="6.4299178"
          x="911.8125"
@@ -2038,3143 +1952,3242 @@
          x="911.8125"
          height="3.4620874"
          width="9.9375"
-         id="rect5055"
+         id="rect5088"
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5053-8"
+         id="rect5090"
          width="9.9375"
          height="6.4299173"
          x="912.28125"
          y="184.36314" />
     </g>
-    <rect
-       inkscape:label="#rect4954"
-       y="-983.47589"
-       x="509.09619"
-       height="33.214977"
-       width="7.7970567"
-       id="rect5040"
-       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:3.45797205;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       transform="matrix(0,1,-1,0,0,0)" />
+    <g
+       transform="translate(0.28284271,0)"
+       id="g4317">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         x="1086.9194"
+         y="183.6866"
+         id="text5130"
+         transform="scale(0.87678236,1.1405339)"><tspan
+           sodipodi:role="line"
+           id="tspan5128"
+           x="1086.9194"
+           y="183.6866"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">6</tspan></text>
+      <text
+         transform="scale(0.87678236,1.1405339)"
+         id="text5134"
+         y="246.63768"
+         x="1086.9194"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
+           y="246.63768"
+           x="1086.9194"
+           id="tspan5132"
+           sodipodi:role="line">2</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         x="1086.9194"
+         y="309.50116"
+         id="text5138"
+         transform="scale(0.87678236,1.1405339)"><tspan
+           sodipodi:role="line"
+           id="tspan5136"
+           x="1086.9194"
+           y="309.50116"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">1</tspan></text>
+    </g>
+    <g
+       transform="matrix(1.0666667,0,0,1.066636,0.28284271,-0.50381959)"
+       id="g5078">
+      <rect
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5047"
+         width="9.9375"
+         height="3.4620874"
+         x="911.8125"
+         y="400.32764" />
+      <rect
+         y="287.02451"
+         x="911.8125"
+         height="3.4620874"
+         width="9.9375"
+         id="rect5049"
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5051"
+         width="9.9375"
+         height="6.4299178"
+         x="911.8125"
+         y="319.32944" />
+      <rect
+         y="251.79059"
+         x="911.8125"
+         height="6.4299178"
+         width="9.9375"
+         id="rect5053"
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:3.43548703;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5055"
+         width="9.9375"
+         height="3.4620874"
+         x="911.8125"
+         y="219.53999" />
+      <rect
+         y="184.36314"
+         x="912.28125"
+         height="6.4299173"
+         width="9.9375"
+         id="rect5053-8"
+         style="fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:4.68189859;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
     <rect
        transform="matrix(0,1,-1,0,0,0)"
-       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:3.89981294;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="VS_pointer"
-       width="6.5950012"
-       height="361.44022"
-       x="509.69724"
-       y="-1060.3188"
+       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:3.45797205;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5040"
+       width="7.7970567"
+       height="33.214977"
+       x="509.09619"
+       y="-983.47589"
+       inkscape:label="#rect4954" />
+    <rect
+       inkscape:transform-center-x="170.07916"
        inkscape:label="#rect4954"
-       inkscape:transform-center-x="170.07916" />
+       y="-1060.3188"
+       x="509.69724"
+       height="361.44022"
+       width="6.5950012"
+       id="VS_pointer"
+       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:3.89981294;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
     <g
-       id="VS_box"
+       transform="translate(0,65.936427)"
        inkscape:label="#g4646"
-       transform="translate(0,65.936427)">
+       id="VS_box">
       <rect
-         y="424.25317"
-         x="983.48328"
-         height="45.6008"
-         width="45.6008"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          id="rect4626"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         width="45.6008"
+         height="45.6008"
+         x="983.48328"
+         y="424.25317" />
       <text
-         inkscape:label="#text5138-5"
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
-         x="1147.7107"
-         y="405.05588"
+         transform="scale(0.87678235,1.1405339)"
          id="VS_digit"
-         transform="scale(0.87678235,1.1405339)"><tspan
-           sodipodi:role="line"
-           id="tspan5136-1"
-           x="1147.7107"
+         y="405.05588"
+         x="1147.7107"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+         xml:space="preserve"
+         inkscape:label="#text5138-5"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577"
            y="405.05588"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">00</tspan></text>
+           x="1147.7107"
+           id="tspan5136-1"
+           sodipodi:role="line">00</tspan></text>
     </g>
   </g>
   <rect
-     y="545.61121"
-     x="769.54877"
-     height="243.41606"
-     width="85.76416"
-     id="rect4313"
-     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-  <rect
      style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="rect4311"
+     id="rect4313"
      width="85.76416"
      height="243.41606"
+     x="769.54877"
+     y="545.61121" />
+  <rect
+     y="237.04375"
      x="769.22241"
-     y="237.04375" />
+     height="243.41606"
+     width="85.76416"
+     id="rect4311"
+     style="fill:#4c4c4c;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <g
-     transform="translate(-723.20023,0)"
+     id="ALT_scale"
      inkscape:label="#g5036"
-     id="ALT_scale">
+     transform="translate(-723.20023,0)">
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,999.43982 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4911"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 1579.3052,999.43982 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <text
-       inkscape:label="#text975"
-       transform="scale(0.95383278,1.0484018)"
-       id="ALT_one"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="1604.5295"
        y="965.32141"
-       x="1604.5295"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-         y="965.32141"
-         x="1604.5295"
+       id="ALT_one"
+       transform="scale(0.95383278,1.0484018)"
+       inkscape:label="#text975"><tspan
+         sodipodi:role="line"
          id="tspan4915"
-         sodipodi:role="line">000</tspan></text>
+         x="1604.5295"
+         y="965.32141"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">000</tspan></text>
     <path
-       sodipodi:nodetypes="ccc"
-       inkscape:connector-curvature="0"
-       id="path4917"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1479.2996,1007.4057 9.3792,-7.97457 -9.3788,-7.9742"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       sodipodi:nodetypes="cc"
+       id="path4917"
        inkscape:connector-curvature="0"
-       id="path4937"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,512.65602 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4937"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="1604.5295"
-       y="501.10501"
+       inkscape:label="#text975"
+       transform="scale(0.95383278,1.0484018)"
        id="ALT_three"
-       transform="scale(0.95383278,1.0484018)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan4941"
-         x="1604.5295"
+       y="501.10501"
+       x="1604.5295"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
          y="501.10501"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">000</tspan></text>
+         x="1604.5295"
+         id="tspan4941"
+         sodipodi:role="line">000</tspan></text>
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1479.2996,520.72043 9.3792,-7.9746 -9.3788,-7.9742"
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
        id="path4943"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
+       d="m 1479.2996,520.72043 9.3792,-7.9746 -9.3788,-7.9742"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4945"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,950.77126 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4945"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,902.1027 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4947"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 1579.3052,902.1027 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4949"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,853.43414 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4949"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,804.76558 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4951"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 1579.3052,804.76558 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4953"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,756.09702 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4953"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,707.42846 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4955"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 1579.3052,707.42846 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4957"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,658.7599 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4957"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,610.09134 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4959"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 1579.3052,610.09134 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path4961"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 1579.3052,561.42278 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path4961"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,26.06931 -11.3041,0"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path5031"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <text
-       inkscape:label="#text975"
-       transform="scale(0.95383278,1.0484018)"
-       id="ALT_five"
-       y="36.888714"
-       x="1604.5295"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-         y="36.888714"
-         x="1604.5295"
-         id="tspan5035"
-         sodipodi:role="line">000</tspan></text>
-    <path
-       sodipodi:nodetypes="ccc"
-       inkscape:connector-curvature="0"
-       id="path5037"
-       d="m 1479.2996,34.03522 9.3792,-7.9746 -9.3788,-7.9742"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,464.08605 -11.3041,0"
-       id="path5039"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path5041"
-       d="m 1579.3052,415.41749 -11.3041,0"
+       d="m 1579.3052,26.06931 -11.3041,0"
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,366.74893 -11.3041,0"
-       id="path5043"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path5045"
-       d="m 1579.3052,318.08037 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,269.41181 -11.3041,0"
-       id="path5047"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path5049"
-       d="m 1579.3052,220.74325 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,172.07469 -11.3041,0"
-       id="path5051"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path5053"
-       d="m 1579.3052,123.40613 -11.3041,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1579.3052,74.73757 -11.3041,0"
-       id="path5055"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <text
-       inkscape:label="#text975"
-       transform="scale(0.95383278,1.0484018)"
-       id="ALT_four"
-       y="268.99725"
-       x="1604.5295"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-         y="268.99725"
-         x="1604.5295"
-         id="tspan5014"
-         sodipodi:role="line">000</tspan></text>
-    <path
-       sodipodi:nodetypes="ccc"
-       inkscape:connector-curvature="0"
-       id="path5016"
-       d="m 1479.2996,277.37822 9.3792,-7.9746 -9.3788,-7.9742"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
        x="1604.5295"
-       y="733.21313"
-       id="ALT_two"
+       y="36.888714"
+       id="ALT_five"
        transform="scale(0.95383278,1.0484018)"
        inkscape:label="#text975"><tspan
          sodipodi:role="line"
-         id="tspan5026"
+         id="tspan5035"
          x="1604.5295"
-         y="733.21313"
+         y="36.888714"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">000</tspan></text>
     <path
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 1479.2996,764.06299 9.3792,-7.97457 -9.3788,-7.9742"
-       id="path5028"
+       d="m 1479.2996,34.03522 9.3792,-7.9746 -9.3788,-7.9742"
+       id="path5037"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5039"
+       d="m 1579.3052,464.08605 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 1579.3052,415.41749 -11.3041,0"
+       id="path5041"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5043"
+       d="m 1579.3052,366.74893 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 1579.3052,318.08037 -11.3041,0"
+       id="path5045"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5047"
+       d="m 1579.3052,269.41181 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 1579.3052,220.74325 -11.3041,0"
+       id="path5049"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5051"
+       d="m 1579.3052,172.07469 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 1579.3052,123.40613 -11.3041,0"
+       id="path5053"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5055"
+       d="m 1579.3052,74.73757 -11.3041,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="1604.5295"
+       y="268.99725"
+       id="ALT_four"
+       transform="scale(0.95383278,1.0484018)"
+       inkscape:label="#text975"><tspan
+         sodipodi:role="line"
+         id="tspan5014"
+         x="1604.5295"
+         y="268.99725"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">000</tspan></text>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 1479.2996,277.37822 9.3792,-7.9746 -9.3788,-7.9742"
+       id="path5016"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95383278,1.0484018)"
+       id="ALT_two"
+       y="733.21313"
+       x="1604.5295"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+         y="733.21313"
+         x="1604.5295"
+         id="tspan5026"
+         sodipodi:role="line">000</tspan></text>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path5028"
+       d="m 1479.2996,764.06299 9.3792,-7.97457 -9.3788,-7.9742"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   </g>
   <rect
-     inkscape:label="#rect4290"
-     y="6.0090518"
-     x="59.092628"
-     height="84.381813"
-     width="102.47213"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
      id="FMA_man_box"
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+     width="102.47213"
+     height="84.381813"
+     x="59.092628"
+     y="6.0090518"
+     inkscape:label="#rect4290" />
+  <text
+     inkscape:label="#text983"
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="125.31013"
+     y="74.429817"
+     id="FMA_manmode"
+     transform="scale(0.87678236,1.1405339)"><tspan
+       sodipodi:role="line"
+       id="tspan4307"
+       x="125.31013"
+       y="74.429817"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">TOGA</tspan></text>
   <text
      transform="scale(0.87678236,1.1405339)"
-     id="FMA_manmode"
-     y="74.429817"
-     x="125.31013"
+     id="FMA_man"
+     y="33.759209"
+     x="125.84993"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577"
-       y="74.429817"
-       x="125.31013"
-       id="tspan4307"
-       sodipodi:role="line">TOGA</tspan></text>
-  <text
-     inkscape:label="#text983"
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="125.84993"
-     y="33.759209"
-     id="FMA_man"
-     transform="scale(0.87678236,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan4303"
-       x="125.84993"
        y="33.759209"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">MAN</tspan></text>
-  <path
-     inkscape:label="#path987"
-     sodipodi:nodetypes="cc"
-     inkscape:connector-curvature="0"
-     id="FMA_Middle1"
-     d="m 432.8701,137.60788 0,-135.9564212"
-     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-  <text
-     inkscape:label="#text983"
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="505.48523"
-     y="115.0584"
-     id="FMA_ctr_msg"
-     transform="scale(0.87678236,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan4614"
-       x="505.48523"
-       y="115.0584"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.657577">MAN PITCH TRIM ONLY</tspan></text>
+       x="125.84993"
+       id="tspan4303"
+       sodipodi:role="line">MAN</tspan></text>
   <path
      style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     d="m 432.8701,90.374503 0,-88.7230442"
-     id="FMA_Middle2"
+     d="m 432.8701,137.60788 0,-135.9564212"
+     id="FMA_Middle1"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cc"
      inkscape:label="#path987" />
   <text
-     transform="scale(0.87678237,1.1405339)"
-     id="FMA_pitch"
-     y="34.986706"
-     x="370.20218"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     transform="scale(0.87678236,1.1405339)"
+     id="FMA_ctr_msg"
+     y="115.0584"
+     x="505.48523"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577"
-       y="34.986706"
-       x="370.20218"
-       id="tspan4244"
-       sodipodi:role="line">ALT</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.657577"
+       y="115.0584"
+       x="505.48523"
+       id="tspan4614"
+       sodipodi:role="line">MAN PITCH TRIM ONLY</tspan></text>
+  <path
+     inkscape:label="#path987"
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="FMA_Middle2"
+     d="m 432.8701,90.374503 0,-88.7230442"
+     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <text
      inkscape:label="#text983"
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="422.80801"
-     y="74.709473"
-     id="FMA_pitcharm"
-     transform="scale(0.87678236,1.1405339)"><tspan
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="370.20218"
+     y="34.986706"
+     id="FMA_pitch"
+     transform="scale(0.87678237,1.1405339)"><tspan
        sodipodi:role="line"
-       id="tspan4248"
-       x="422.80801"
-       y="74.709473"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577">G/S</tspan></text>
+       id="tspan4244"
+       x="370.20218"
+       y="34.986706"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">ALT</tspan></text>
   <text
      transform="scale(0.87678236,1.1405339)"
-     id="FMA_pitcharm2"
+     id="FMA_pitcharm"
      y="74.709473"
-     x="305.3663"
+     x="422.80801"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577"
        y="74.709473"
-       x="305.3663"
-       id="tspan4252"
-       sodipodi:role="line">CLB</tspan></text>
-  <text
-     inkscape:label="#text983"
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="629.61298"
-     y="34.635147"
-     id="FMA_roll"
-     transform="scale(0.87678237,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan4256"
-       x="629.61298"
-       y="34.635147"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">LOC</tspan></text>
+       x="422.80801"
+       id="tspan4248"
+       sodipodi:role="line">G/S</tspan></text>
   <text
      inkscape:label="#text983"
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="629.22266"
+     x="305.3663"
      y="74.709473"
-     id="FMA_rollarm"
-     transform="scale(0.87678237,1.1405339)"><tspan
+     id="FMA_pitcharm2"
+     transform="scale(0.87678236,1.1405339)"><tspan
        sodipodi:role="line"
-       id="tspan4260"
-       x="629.22266"
+       id="tspan4252"
+       x="305.3663"
        y="74.709473"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577">NAV</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577">CLB</tspan></text>
+  <text
+     transform="scale(0.87678237,1.1405339)"
+     id="FMA_roll"
+     y="34.635147"
+     x="629.61298"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     xml:space="preserve"
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577"
+       y="34.635147"
+       x="629.61298"
+       id="tspan4256"
+       sodipodi:role="line">LOC</tspan></text>
+  <text
+     transform="scale(0.87678237,1.1405339)"
+     id="FMA_rollarm"
+     y="74.709473"
+     x="629.22266"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     xml:space="preserve"
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577"
+       y="74.709473"
+       x="629.22266"
+       id="tspan4260"
+       sodipodi:role="line">NAV</tspan></text>
   <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_pitch_box"
-     width="198.27213"
-     height="36.781818"
-     x="225.69263"
+     inkscape:label="#rect4290"
      y="7.4090519"
-     inkscape:label="#rect4290" />
-  <rect
-     inkscape:label="#rect4290"
-     y="52.623405"
      x="225.69263"
      height="36.781818"
      width="198.27213"
-     id="FMA_pitcharm_box"
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-  <rect
-     inkscape:label="#rect4290"
-     y="7.4717641"
-     x="441.85077"
-     height="36.725567"
-     width="218.77071"
-     id="FMA_roll_box"
+     id="FMA_pitch_box"
      style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <rect
      style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_rollarm_box"
+     id="FMA_pitcharm_box"
+     width="198.27213"
+     height="36.781818"
+     x="225.69263"
+     y="52.623405"
+     inkscape:label="#rect4290" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     id="FMA_roll_box"
      width="218.77071"
      height="36.725567"
      x="441.85077"
-     y="52.616997"
+     y="7.4717641"
      inkscape:label="#rect4290" />
+  <rect
+     inkscape:label="#rect4290"
+     y="52.616997"
+     x="441.85077"
+     height="36.725567"
+     width="218.77071"
+     id="FMA_rollarm_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <g
-     transform="translate(0,4.4)"
+     id="LOC_scale"
      inkscape:label="#g4578"
-     id="LOC_scale">
+     transform="translate(0,4.4)">
     <rect
-       y="816.11987"
-       x="444.25851"
-       height="41.291069"
-       width="7.7972813"
+       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:3.91476655;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4858"
-       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:3.91476655;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       width="7.7972813"
+       height="41.291069"
+       x="444.25851"
+       y="816.11987" />
     <g
        id="g4523">
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 355.793,836.92648 c 0,3.51647 -2.85073,6.36714 -6.3673,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.3673,2.85066 6.3673,6.36712 z"
+         sodipodi:nodetypes="zzzzz"
+         inkscape:connector-curvature="0"
          id="path4874"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         d="m 355.793,836.92648 c 0,3.51647 -2.85073,6.36714 -6.3673,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.3673,2.85066 6.3673,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 257.81742,836.9262 c 0,3.51647 -2.85073,6.36714 -6.36731,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.36731,2.85066 6.36731,6.36712 z"
-         id="circle4876"
+         sodipodi:nodetypes="zzzzz"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         id="circle4876"
+         d="m 257.81742,836.9262 c 0,3.51647 -2.85073,6.36714 -6.36731,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.36731,2.85066 6.36731,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
-       id="g4527"
-       transform="translate(1.8616028,0)">
+       transform="translate(1.8616028,0)"
+       id="g4527">
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 649.3818,836.9262 c 0,3.51647 -2.85073,6.36714 -6.36731,6.36714 -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36714 0,-3.51647 2.85075,-6.36712 6.36731,-6.36712 3.51657,0 6.36731,2.85066 6.36731,6.36712 z"
+         sodipodi:nodetypes="zzzzz"
+         inkscape:connector-curvature="0"
          id="circle4878"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         d="m 649.3818,836.9262 c 0,3.51647 -2.85073,6.36714 -6.36731,6.36714 -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36714 0,-3.51647 2.85075,-6.36712 6.36731,-6.36712 3.51657,0 6.36731,2.85066 6.36731,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 551.40661,836.9262 c 0,3.51647 -2.85074,6.36714 -6.36731,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.36731,2.85066 6.36731,6.36712 z"
-         id="circle4880"
+         sodipodi:nodetypes="zzzzz"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         id="circle4880"
+         d="m 551.40661,836.9262 c 0,3.51647 -2.85074,6.36714 -6.36731,6.36714 -3.51658,0 -6.36732,-2.85066 -6.36732,-6.36714 0,-3.51647 2.85075,-6.36712 6.36732,-6.36712 3.51656,0 6.36731,2.85066 6.36731,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
   </g>
   <rect
-     inkscape:label="#rect4872"
-     transform="matrix(0.83705476,-0.54711912,0.83705476,0.54711912,0,0)"
-     y="1019.8428"
-     x="-517.64343"
-     height="33.21196"
-     width="33.21196"
+     style="fill:none;fill-opacity:1;stroke:#b055be;stroke-width:4.0350337;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="LOC_pointer"
-     style="fill:none;fill-opacity:1;stroke:#b055be;stroke-width:4.0350337;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     width="33.21196"
+     height="33.21196"
+     x="-517.64343"
+     y="1019.8428"
+     transform="matrix(0.83705476,-0.54711912,0.83705476,0.54711912,0,0)"
+     inkscape:label="#rect4872" />
   <g
-     inkscape:label="#g4828"
-     id="ALT_group2">
+     id="ALT_group2"
+     inkscape:label="#g4828">
     <rect
-       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.4806304;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4925"
-       width="7.7970567"
-       height="49.153526"
-       x="509.50464"
+       transform="matrix(0,1,-1,0,0,0)"
        y="-747.05353"
-       transform="matrix(0,1,-1,0,0,0)" />
+       x="509.50464"
+       height="49.153526"
+       width="7.7970567"
+       id="rect4925"
+       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.4806304;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <text
-       inkscape:label="#text979"
-       transform="scale(1.0000144,0.9999856)"
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       id="QNH_std"
+       y="885.26117"
        x="859.21783"
-       y="885.26117"
-       id="QNH_std"><tspan
-         sodipodi:role="line"
-         id="tspan4618"
-         x="859.21783"
-         y="885.26117"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.3994px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.75">STD</tspan></text>
-    <g
-       id="ALT_target"
-       inkscape:label="#g4832">
-      <rect
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4802"
-         width="84.638374"
-         height="58.155445"
-         x="753.69922"
-         y="483.91519"
-         inkscape:label="#rect4671" />
-      <rect
-         inkscape:label="#rect4671"
-         y="454.01135"
-         x="753.69922"
-         height="117.40934"
-         width="13.893659"
-         id="rect5408"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         inkscape:label="#path4943-1"
-         style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 806.4248,453.9808 0,117.4912 -50.3256,0 0,-50.7712 9.37937,-7.97477 -9.37857,-7.97403 0,-50.7712 50.3248,0"
-         id="ALT_target_box"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccc" />
-      <rect
-         inkscape:label="#rect4671"
-         y="483.91519"
-         x="771.4729"
-         height="58.155445"
-         width="83.838371"
-         id="rect4796"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-         x="890.99316"
-         y="506.26898"
-         id="ALT_target_digit"
-         transform="scale(0.95383277,1.0484018)"
-         inkscape:label="#text975"><tspan
-           sodipodi:role="line"
-           id="tspan4800"
-           x="890.99316"
-           y="506.26898"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke-width:0.75">000</tspan></text>
-    </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="801.06317"
-       y="787.28491"
-       id="ALT_digit_DN"
-       transform="scale(0.95382558,1.0484097)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan5112"
-         x="801.06317"
-         y="787.28491"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">FL 000</tspan></text>
-    <text
-       inkscape:label="#text975"
-       transform="scale(0.95382558,1.0484097)"
-       id="ALT_digit_UP"
-       y="220.32645"
-       x="801.06317"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
-         y="220.32645"
-         x="801.06317"
-         id="tspan5116"
-         sodipodi:role="line">FL 000</tspan></text>
-    <rect
-       inkscape:label="#rect4290"
-       y="853.61444"
-       x="817.05194"
-       height="36.839172"
-       width="84.253624"
-       id="QNH_box"
-       style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-       x="887.71545"
-       y="775.94104"
-       id="QNH"
-       transform="scale(0.87678236,1.1405339)"
-       inkscape:label="#text5026"><tspan
-         sodipodi:role="line"
-         id="tspan5024"
-         x="887.71545"
-         y="775.94104"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577">QNH</tspan></text>
-    <text
-       id="QNH_setting"
-       y="885.26117"
-       x="907.61713"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
        xml:space="preserve"
        transform="scale(1.0000144,0.9999856)"
        inkscape:label="#text979"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.3994px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
          y="885.26117"
-         x="907.61713"
+         x="859.21783"
+         id="tspan4618"
+         sodipodi:role="line">STD</tspan></text>
+    <g
+       inkscape:label="#g4832"
+       id="ALT_target">
+      <rect
+         inkscape:label="#rect4671"
+         y="483.91519"
+         x="753.69922"
+         height="58.155445"
+         width="84.638374"
+         id="rect4802"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect5408"
+         width="13.893659"
+         height="117.40934"
+         x="753.69922"
+         y="454.01135"
+         inkscape:label="#rect4671" />
+      <path
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0"
+         id="ALT_target_box"
+         d="m 806.4248,453.9808 0,117.4912 -50.3256,0 0,-50.7712 9.37937,-7.97477 -9.37857,-7.97403 0,-50.7712 50.3248,0"
+         style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         inkscape:label="#path4943-1" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4796"
+         width="83.838371"
+         height="58.155445"
+         x="771.4729"
+         y="483.91519"
+         inkscape:label="#rect4671" />
+      <text
+         inkscape:label="#text975"
+         transform="scale(0.95383277,1.0484018)"
+         id="ALT_target_digit"
+         y="506.26898"
+         x="890.99316"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+           y="506.26898"
+           x="890.99316"
+           id="tspan4800"
+           sodipodi:role="line">000</tspan></text>
+    </g>
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95382558,1.0484097)"
+       id="ALT_digit_DN"
+       y="787.28491"
+       x="801.06317"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+         y="787.28491"
+         x="801.06317"
+         id="tspan5112"
+         sodipodi:role="line">FL 000</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="801.06317"
+       y="220.32645"
+       id="ALT_digit_UP"
+       transform="scale(0.95382558,1.0484097)"
+       inkscape:label="#text975"><tspan
+         sodipodi:role="line"
+         id="tspan5116"
+         x="801.06317"
+         y="220.32645"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">FL 000</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       id="QNH_box"
+       width="84.253624"
+       height="36.839172"
+       x="817.05194"
+       y="853.61444"
+       inkscape:label="#rect4290" />
+    <text
+       inkscape:label="#text5026"
+       transform="scale(0.87678236,1.1405339)"
+       id="QNH"
+       y="775.94104"
+       x="887.71545"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.756px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
+         y="775.94104"
+         x="887.71545"
+         id="tspan5024"
+         sodipodi:role="line">QNH</tspan></text>
+    <text
+       inkscape:label="#text979"
+       transform="scale(1.0000144,0.9999856)"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="907.61713"
+       y="885.26117"
+       id="QNH_setting"><tspan
+         sodipodi:role="line"
          id="tspan977"
-         sodipodi:role="line">1013</tspan></text>
+         x="907.61713"
+         y="885.26117"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.3994px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.75">1013</tspan></text>
   </g>
   <g
-     transform="translate(5.2325902,0)"
+     id="GS_scale"
      inkscape:label="#g4569"
-     id="GS_scale">
+     transform="translate(5.2325902,0)">
     <rect
-       transform="matrix(0,1,-1,0,0,0)"
-       y="-741.82098"
-       x="509.50464"
-       height="49.153526"
-       width="7.7970567"
+       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.4806304;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4898"
-       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.4806304;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       width="7.7970567"
+       height="49.153526"
+       x="509.50464"
+       y="-741.82098"
+       transform="matrix(0,1,-1,0,0,0)" />
     <g
-       id="g4531"
-       transform="translate(0,-1.0792028)">
+       transform="translate(0,-1.0792028)"
+       id="g4531">
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 714.66382,422.10642 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
+         sodipodi:nodetypes="zzzzz"
+         inkscape:connector-curvature="0"
          id="circle4927"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         d="m 714.66382,422.10642 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 714.66382,324.13136 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
-         id="circle4929"
+         sodipodi:nodetypes="zzzzz"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         id="circle4929"
+         d="m 714.66382,324.13136 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        id="g4565">
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 714.66382,716.47762 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51647 2.85073,-6.36714 6.36731,-6.36714 3.51658,0 6.36732,2.85066 6.36732,6.36714 0,3.51647 -2.85075,6.36712 -6.36732,6.36712 z"
+         sodipodi:nodetypes="zzzzz"
+         inkscape:connector-curvature="0"
          id="circle4931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         d="m 714.66382,716.47762 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51647 2.85073,-6.36714 6.36731,-6.36714 3.51658,0 6.36732,2.85066 6.36732,6.36714 0,3.51647 -2.85075,6.36712 -6.36732,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 714.66382,618.50242 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51647 2.85073,-6.36714 6.36731,-6.36714 3.51658,0 6.36732,2.85066 6.36732,6.36714 0,3.51647 -2.85075,6.36712 -6.36732,6.36712 z"
-         id="circle4933"
+         sodipodi:nodetypes="zzzzz"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="zzzzz" />
+         id="circle4933"
+         d="m 714.66382,618.50242 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51647 2.85073,-6.36714 6.36731,-6.36714 3.51658,0 6.36732,2.85066 6.36732,6.36714 0,3.51647 -2.85075,6.36712 -6.36732,6.36712 z"
+         style="fill:none;fill-opacity:1;stroke:#cecdce;stroke-width:2.39996552;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
   </g>
   <rect
-     style="fill:none;fill-opacity:1;stroke:#b055be;stroke-width:4.03498697;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="GS_pointer"
-     width="33.211578"
-     height="33.211578"
-     x="949.0885"
-     y="-368.9328"
+     inkscape:label="#rect4872"
      transform="matrix(0.54714118,0.83704034,-0.54714118,0.83704034,0,0)"
-     inkscape:label="#rect4872" />
+     y="-368.9328"
+     x="949.0885"
+     height="33.211578"
+     width="33.211578"
+     id="GS_pointer"
+     style="fill:none;fill-opacity:1;stroke:#b055be;stroke-width:4.03498697;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
-     inkscape:label="#rect4671"
-     y="483.25833"
-     x="768.71039"
-     height="59.519768"
-     width="89.289597"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
      id="ALT_mask"
-     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+     width="89.289597"
+     height="59.519768"
+     x="768.71039"
+     y="483.25833"
+     inkscape:label="#rect4671" />
   <rect
-     inkscape:label="#rect9211"
-     y="467.59009"
-     x="858.00543"
-     height="90.122147"
-     width="48.851151"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="ALT_tens_clip"
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     width="48.851151"
+     height="90.122147"
+     x="858.00543"
+     y="467.59009"
+     inkscape:label="#rect9211" />
   <g
-     inkscape:label="#g5167"
-     id="ALT_frame">
+     id="ALT_frame"
+     inkscape:label="#g5167">
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 856.91323,547.2032 0,240.22596"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
        id="path4309"
+       d="m 856.91323,547.2032 0,240.22596"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.20000005;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 856.91323,236.93596 0,241.91039"
+       id="path4984"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path4984"
-       d="m 856.91323,236.93596 0,241.91039"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       id="path965"
+       d="m 768.94214,790.64777 132.99332,0"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.16267705;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <path
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.16267705;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 768.94214,790.64777 132.99332,0"
-       id="path965"
+       d="m 768.94214,235.42646 132.99332,0"
+       id="path967"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path967"
-       d="m 768.94214,235.42646 132.99332,0"
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.16267705;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   </g>
   <g
-     inkscape:label="#g5379"
-     id="ALT_group">
+     id="ALT_group"
+     inkscape:label="#g5379">
     <g
-       inkscape:label="#g5173"
-       id="ALT_box">
+       id="ALT_box"
+       inkscape:label="#g5173">
       <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path1283"
+         style="fill:#000000;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="m 856.4002,481.90842 2.2e-4,-15.92813 h 52.07464 v 93.34657 h -52.07457 v -15.26583"
-         style="fill:#000000;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="path1283"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 770.31078,481.90873 86.08971,-3.1e-4"
+         id="path1285"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path1285"
-         d="m 770.31078,481.90873 86.08971,-3.1e-4"
-         style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 770.31078,544.06163 86.08971,-6e-4"
          id="path1287"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
+         d="m 770.31078,544.06163 86.08971,-6e-4"
+         style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     </g>
     <text
-       id="ALT_tens"
-       y="289.66925"
-       x="898.703"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"
+       transform="scale(0.96366556,1.0377044)"
        inkscape:label="#text913"
-       transform="scale(0.96366556,1.0377044)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:94.99999881%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="289.66925"
-         x="898.703"
-         id="tspan911"
-         sodipodi:role="line"> </tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="317.73038"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan919">40</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="344.55804"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan4300">20</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="371.38571"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan931">00</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="398.21338"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan927">80</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="425.04105"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan925">60</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="451.86871"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan923">40</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="478.69638"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan921">20</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="505.52405"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan917">00</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="532.35168"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan915">80</tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.83639908px;line-height:87.00000048%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="559.17938"
-         x="898.703"
-         sodipodi:role="line"
-         id="tspan4302">60</tspan></text>
-    <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="890.99316"
-       y="506.23941"
-       id="ALT_digits"
-       transform="scale(0.95383277,1.0484018)"
-       inkscape:label="#text975"><tspan
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="898.703"
+       y="289.66925"
+       id="ALT_tens"><tspan
          sodipodi:role="line"
-         id="tspan973"
-         x="890.99316"
+         id="tspan911"
+         x="898.703"
+         y="289.66925"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:95%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75"> </tspan><tspan
+         id="tspan919"
+         sodipodi:role="line"
+         x="898.703"
+         y="317.73038"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">40</tspan><tspan
+         id="tspan4300"
+         sodipodi:role="line"
+         x="898.703"
+         y="344.55804"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">20</tspan><tspan
+         id="tspan931"
+         sodipodi:role="line"
+         x="898.703"
+         y="371.38571"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">00</tspan><tspan
+         id="tspan927"
+         sodipodi:role="line"
+         x="898.703"
+         y="398.21338"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">80</tspan><tspan
+         id="tspan925"
+         sodipodi:role="line"
+         x="898.703"
+         y="425.04105"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">60</tspan><tspan
+         id="tspan923"
+         sodipodi:role="line"
+         x="898.703"
+         y="451.86871"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">40</tspan><tspan
+         id="tspan921"
+         sodipodi:role="line"
+         x="898.703"
+         y="478.69638"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">20</tspan><tspan
+         id="tspan917"
+         sodipodi:role="line"
+         x="898.703"
+         y="505.52405"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">00</tspan><tspan
+         id="tspan915"
+         sodipodi:role="line"
+         x="898.703"
+         y="532.35168"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">80</tspan><tspan
+         id="tspan4302"
+         sodipodi:role="line"
+         x="898.703"
+         y="559.17938"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30.8364px;line-height:87%;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#0dc04b;fill-opacity:1;stroke-width:0.75">60</tspan></text>
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95383277,1.0484018)"
+       id="ALT_digits"
+       y="506.23941"
+       x="890.99316"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
          y="506.23941"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.83480072px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke-width:0.75">00</tspan></text>
+         x="890.99316"
+         id="tspan973"
+         sodipodi:role="line">00</tspan></text>
   </g>
-  <path
-     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     d="m 216.77826,137.60788 0,-135.9564208"
-     id="path985"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cc" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     d="m 669.59655,137.60788 0,-135.9564208"
-     id="path989"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cc" />
   <path
      sodipodi:nodetypes="cc"
      inkscape:connector-curvature="0"
-     id="path991"
-     d="m 864.89945,137.60788 0,-135.9564208"
+     id="path985"
+     d="m 216.77826,137.60788 0,-135.9564208"
      style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  <path
+     sodipodi:nodetypes="cc"
+     inkscape:connector-curvature="0"
+     id="path989"
+     d="m 669.59655,137.60788 0,-135.9564208"
+     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#515256;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     d="m 864.89945,137.60788 0,-135.9564208"
+     id="path991"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
   <text
-     transform="scale(0.87678236,1.1405339)"
+     inkscape:label="#text983"
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="1080.6229"
+     y="34.635155"
      id="FMA_ap"
-     y="34.635155"
-     x="1080.6229"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     xml:space="preserve"
-     inkscape:label="#text983"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-       y="34.635155"
-       x="1080.6229"
+     transform="scale(0.87678236,1.1405339)"><tspan
+       sodipodi:role="line"
        id="tspan4268"
-       sodipodi:role="line">AP 1+2</tspan></text>
-  <text
-     inkscape:label="#text983"
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="1080.6229"
-     y="74.709656"
-     id="FMA_fd"
-     transform="scale(0.87678236,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan4272"
        x="1080.6229"
-       y="74.709656"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">1 FD 2</tspan></text>
-  <text
-     transform="scale(0.87678236,1.1405339)"
-     id="FMA_athr"
-     y="115.05846"
-     x="1080.6229"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     xml:space="preserve"
-     inkscape:label="#text983"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-       y="115.05846"
-       x="1080.6229"
-       id="tspan4276"
-       sodipodi:role="line">A/THR</tspan></text>
-  <text
-     inkscape:label="#text983"
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="874.48682"
-     y="34.635155"
-     id="FMA_catmode"
-     transform="scale(0.87678236,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan4280"
-       x="874.48682"
        y="34.635155"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">CAT 3</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">AP 1+2</tspan></text>
   <text
      transform="scale(0.87678236,1.1405339)"
-     id="FMA_cattype"
+     id="FMA_fd"
      y="74.709656"
-     x="874.48682"
+     x="1080.6229"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
        y="74.709656"
+       x="1080.6229"
+       id="tspan4272"
+       sodipodi:role="line">1 FD 2</tspan></text>
+  <text
+     inkscape:label="#text983"
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="1080.6229"
+     y="115.05846"
+     id="FMA_athr"
+     transform="scale(0.87678236,1.1405339)"><tspan
+       sodipodi:role="line"
+       id="tspan4276"
+       x="1080.6229"
+       y="115.05846"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">A/THR</tspan></text>
+  <text
+     transform="scale(0.87678236,1.1405339)"
+     id="FMA_catmode"
+     y="34.635155"
+     x="874.48682"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     xml:space="preserve"
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
+       y="34.635155"
        x="874.48682"
-       id="tspan4284"
-       sodipodi:role="line">DUAL</tspan></text>
+       id="tspan4280"
+       sodipodi:role="line">CAT 3</tspan></text>
   <text
      inkscape:label="#text983"
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
      x="874.48682"
-     y="115.05846"
-     id="FMA_nodh"
+     y="74.709656"
+     id="FMA_cattype"
      transform="scale(0.87678236,1.1405339)"><tspan
        sodipodi:role="line"
-       id="tspan4288"
+       id="tspan4284"
        x="874.48682"
-       y="115.05846"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">NO  DH</tspan></text>
-  <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_catmode_box"
-     width="178.44022"
-     height="36.839169"
-     x="677.62024"
-     y="7.345109"
-     inkscape:label="#rect4290" />
-  <rect
-     inkscape:label="#rect4290"
-     y="52.629978"
-     x="677.62024"
-     height="36.839169"
-     width="178.44022"
-     id="FMA_cattype_box"
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-  <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_dh_box"
-     width="178.44022"
-     height="36.839169"
-     x="677.62024"
-     y="98.663033"
-     inkscape:label="#rect4290" />
-  <rect
-     inkscape:label="#rect4290"
-     y="7.3453288"
-     x="873.73383"
-     height="36.838722"
-     width="143.56436"
-     id="FMA_ap_box"
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-  <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_fd_box"
-     width="143.56436"
-     height="36.838722"
-     x="873.73383"
-     y="52.630581"
-     inkscape:label="#rect4290" />
-  <rect
-     inkscape:label="#rect4290"
-     y="98.663651"
-     x="873.73383"
-     height="36.838722"
-     width="143.56436"
-     id="FMA_athr_box"
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+       y="74.709656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">DUAL</tspan></text>
   <text
-     inkscape:label="#text983"
+     transform="scale(0.87678236,1.1405339)"
+     id="FMA_nodh"
+     y="115.05846"
+     x="874.48682"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="123.23077"
-     y="34.635437"
-     id="FMA_thrust"
-     transform="scale(0.87678236,1.1405339)"><tspan
-       sodipodi:role="line"
-       id="tspan981"
-       x="123.23077"
-       y="34.635437"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">SPEED</tspan></text>
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
+       y="115.05846"
+       x="874.48682"
+       id="tspan4288"
+       sodipodi:role="line">NO  DH</tspan></text>
   <rect
      inkscape:label="#rect4290"
-     y="7.4160867"
-     x="7.3189778"
-     height="36.76775"
-     width="200.56206"
-     id="FMA_thrust_box"
+     y="7.345109"
+     x="677.62024"
+     height="36.839169"
+     width="178.44022"
+     id="FMA_catmode_box"
      style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_cat_box"
-     width="178.44023"
-     height="82.123947"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     id="FMA_cattype_box"
+     width="178.44022"
+     height="36.839169"
      x="677.62024"
-     y="7.3451986"
+     y="52.629978"
+     inkscape:label="#rect4290" />
+  <rect
+     inkscape:label="#rect4290"
+     y="98.663033"
+     x="677.62024"
+     height="36.839169"
+     width="178.44022"
+     id="FMA_dh_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     id="FMA_ap_box"
+     width="143.56436"
+     height="36.838722"
+     x="873.73383"
+     y="7.3453288"
+     inkscape:label="#rect4290" />
+  <rect
+     inkscape:label="#rect4290"
+     y="52.630581"
+     x="873.73383"
+     height="36.838722"
+     width="143.56436"
+     id="FMA_fd_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+     id="FMA_athr_box"
+     width="143.56436"
+     height="36.838722"
+     x="873.73383"
+     y="98.663651"
      inkscape:label="#rect4290" />
   <text
      transform="scale(0.87678236,1.1405339)"
-     id="FMA_combined"
+     id="FMA_thrust"
      y="34.635437"
-     x="505.48523"
+     x="123.23077"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577"
        y="34.635437"
-       x="505.48523"
-       id="tspan4354"
-       sodipodi:role="line">FLARE</tspan></text>
+       x="123.23077"
+       id="tspan981"
+       sodipodi:role="line">SPEED</tspan></text>
   <rect
      style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_combined_box"
-     width="293.76205"
+     id="FMA_thrust_box"
+     width="200.56206"
      height="36.76775"
-     x="296.9281"
+     x="7.3189778"
      y="7.4160867"
      inkscape:label="#rect4290" />
-  <text
-     transform="scale(0.87678236,1.1405339)"
-     id="FMA_dh"
-     y="115.05846"
-     x="826.09802"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     xml:space="preserve"
-     inkscape:label="#text983"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577"
-       y="115.05846"
-       x="826.09802"
-       id="tspan4301"
-       sodipodi:role="line">DH</tspan></text>
+  <rect
+     inkscape:label="#rect4290"
+     y="7.3451986"
+     x="677.62024"
+     height="82.123947"
+     width="178.44023"
+     id="FMA_cat_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <text
      inkscape:label="#text983"
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="922.034"
-     y="115.05846"
-     id="FMA_dhn"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="505.48523"
+     y="34.635437"
+     id="FMA_combined"
      transform="scale(0.87678236,1.1405339)"><tspan
        sodipodi:role="line"
-       id="tspan4305"
-       x="922.034"
-       y="115.05846"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577">250</tspan></text>
+       id="tspan4354"
+       x="505.48523"
+       y="34.635437"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#0dc04b;fill-opacity:1;stroke-width:0.657577">FLARE</tspan></text>
   <rect
-     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-     id="FMA_flx_box"
-     width="171.9402"
-     height="84.557259"
-     x="21.79715"
-     y="5.9218655"
-     inkscape:label="#rect4290" />
+     inkscape:label="#rect4290"
+     y="7.4160867"
+     x="296.9281"
+     height="36.76775"
+     width="293.76205"
+     id="FMA_combined_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.39996576;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   <text
      inkscape:label="#text983"
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
-     x="185.85408"
-     y="74.429558"
-     id="FMA_flxtemp"
-     transform="scale(0.87678235,1.1405339)"><tspan
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="826.09802"
+     y="115.05846"
+     id="FMA_dh"
+     transform="scale(0.87678236,1.1405339)"><tspan
        sodipodi:role="line"
-       id="tspan4316"
-       x="185.85408"
-       y="74.429558"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577">+40</tspan></text>
+       id="tspan4301"
+       x="826.09802"
+       y="115.05846"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#cecdce;fill-opacity:1;stroke-width:0.657577">DH</tspan></text>
   <text
      transform="scale(0.87678236,1.1405339)"
-     id="FMA_lvrclb"
-     y="114.70684"
-     x="123.23077"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     id="FMA_dhn"
+     y="115.05846"
+     x="922.034"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
      xml:space="preserve"
      inkscape:label="#text983"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577"
-       y="114.70684"
-       x="123.23077"
-       id="tspan4294"
-       sodipodi:role="line">LVR  CLB</tspan></text>
-  <g
-     inkscape:label="#g4853"
-     id="HDG_group">
-    <g
-       id="HDG_scale"
-       inkscape:label="#g4743"
-       transform="translate(-104.78479,0)">
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 256.91925,944.75532 0,22.36203"
-         id="path4456-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <text
-         inkscape:label="#text975"
-         transform="scale(0.95383278,1.0484018)"
-         id="HDG_one"
-         y="958.2016"
-         x="269.18036"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-           y="958.2016"
-           x="269.18036"
-           id="tspan4386-6"
-           sodipodi:role="line">00</tspan></text>
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4691"
-         d="m 651.08597,944.75532 0,22.36203"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         x="579.11359"
-         y="958.2016"
-         id="HDG_four"
-         transform="scale(0.95383278,1.0484018)"
-         inkscape:label="#text975"><tspan
-           sodipodi:role="line"
-           id="tspan4695"
-           x="579.11359"
-           y="958.2016"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4697"
-         d="m 306.19037,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4699"
-         d="m 355.46117,944.75532 0,22.36203"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 454.00277,944.75532 0,22.36203"
-         id="path4701"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 552.54437,944.75532 0,22.36203"
-         id="path4703"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         x="372.49115"
-         y="958.2016"
-         id="HDG_two"
-         transform="scale(0.95383278,1.0484018)"
-         inkscape:label="#text975"><tspan
-           sodipodi:role="line"
-           id="tspan4707"
-           x="372.49115"
-           y="958.2016"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
-      <text
-         inkscape:label="#text975"
-         transform="scale(0.95383278,1.0484018)"
-         id="HDG_three"
-         y="958.2016"
-         x="475.80234"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-           y="958.2016"
-           x="475.80234"
-           id="tspan4711"
-           sodipodi:role="line">00</tspan></text>
-      <text
-         inkscape:label="#text975"
-         transform="scale(0.95383278,1.0484018)"
-         id="HDG_five"
-         y="958.2016"
-         x="682.42474"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-           y="958.2016"
-           x="682.42474"
-           id="tspan4715"
-           sodipodi:role="line">00</tspan></text>
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 404.73197,944.75532 0,12.35406"
-         id="path4717"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4719"
-         d="m 503.27357,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 601.81517,944.75532 0,12.35406"
-         id="path4721"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 207.64877,944.75532 0,12.35406"
-         id="path4723"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 749.62718,944.75532 0,22.36203"
-         id="path4725"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         x="785.73553"
-         y="958.2016"
-         id="HDG_six"
-         transform="scale(0.95383278,1.0484018)"
-         inkscape:label="#text975"><tspan
-           sodipodi:role="line"
-           id="tspan4729"
-           x="785.73553"
-           y="958.2016"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4731"
-         d="m 700.35638,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4733"
-         d="m 848.16878,944.75532 0,22.36203"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <text
-         inkscape:label="#text975"
-         transform="scale(0.95383278,1.0484018)"
-         id="HDG_seven"
-         y="958.2016"
-         x="889.04669"
-         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-           y="958.2016"
-           x="889.04669"
-           id="tspan4737"
-           sodipodi:role="line">00</tspan></text>
-      <path
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 798.89798,944.75532 0,12.35406"
-         id="path4739"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4741"
-         d="m 897.43958,944.75532 0,12.35406"
-         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    </g>
-    <rect
-       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.64450645;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="HDG_pointer"
-       width="7.7972717"
-       height="53.319752"
-       x="443.85849"
-       y="907.00177"
-       inkscape:label="#rect4954" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 426.05644,912.48947 43.41526,10e-6 -21.70763,40.47717 z"
-       id="HDG_target"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       inkscape:label="#rect902" />
-    <g
-       id="CRS_pointer"
-       inkscape:label="#g5019"
-       transform="matrix(1.0666667,0,0,1.066636,7.9500002,2.8086774)">
-      <rect
-         y="897.6875"
-         x="409.21875"
-         height="46.03125"
-         width="6.1875"
-         id="rect5013"
-         style="fill:#b055be;fill-opacity:1;stroke:none;stroke-width:2.79342866;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#b055be;fill-opacity:1;stroke:none;stroke-width:2.19441199;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect5015"
-         width="6.1875"
-         height="28.40625"
-         x="929.98438"
-         y="-426.51562" />
-    </g>
-    <rect
-       inkscape:label="#rect4872"
-       transform="matrix(0.57965979,0.8148586,-0.57965979,0.8148586,0,0)"
-       y="194.07515"
-       x="966.534"
-       height="14.344484"
-       width="14.344484"
-       id="TRK_pointer"
-       style="fill:none;fill-opacity:1;stroke:#08b837;stroke-width:3.86463165;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="218.92215"
-       y="895.6087"
-       id="HDG_digit_L"
-       transform="scale(0.95383278,1.0484018)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan4386-5"
-         x="218.92215"
-         y="895.6087"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">000</tspan></text>
-    <text
-       inkscape:label="#text975"
-       transform="scale(0.95383443,1.0484)"
-       id="HDG_digit_R"
-       y="895.61029"
-       x="721.2049"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
-         y="895.61029"
-         x="721.2049"
-         id="tspan4786"
-         sodipodi:role="line">000</tspan></text>
-  </g>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577"
+       y="115.05846"
+       x="922.034"
+       id="tspan4305"
+       sodipodi:role="line">250</tspan></text>
   <rect
-     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="ASI_trend_down_clip"
-     width="117.6912"
-     height="275.79279"
-     x="8.3655996"
-     y="512.82642"
-     inkscape:label="#rect9211" />
+     inkscape:label="#rect4290"
+     y="5.9218655"
+     x="21.79715"
+     height="84.557259"
+     width="171.9402"
+     id="FMA_flx_box"
+     style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.4000001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  <text
+     transform="scale(0.87678235,1.1405339)"
+     id="FMA_flxtemp"
+     y="74.429558"
+     x="185.85408"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     xml:space="preserve"
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#179ab7;fill-opacity:1;stroke-width:0.657577"
+       y="74.429558"
+       x="185.85408"
+       id="tspan4316"
+       sodipodi:role="line">+40</tspan></text>
+  <text
+     inkscape:label="#text983"
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     x="123.23077"
+     y="114.70684"
+     id="FMA_lvrclb"
+     transform="scale(0.87678236,1.1405339)"><tspan
+       sodipodi:role="line"
+       id="tspan4294"
+       x="123.23077"
+       y="114.70684"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">LVR  CLB</tspan></text>
   <g
-     inkscape:label="#g4784"
-     id="ASI_group">
+     id="HDG_group"
+     inkscape:label="#g4853">
     <g
-       transform="translate(427.21679,200.65901)"
-       inkscape:label="#g4996"
-       id="ASI_max">
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4786"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="290.33853" />
-      <rect
-         y="270.33838"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4788"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="246.33833"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4794"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4797"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="226.33818" />
-      <rect
-         y="202.33833"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4799"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4801"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="182.33818" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4803"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="158.33813" />
-      <rect
-         y="138.33798"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4805"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4807"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="114.33834" />
-      <rect
-         y="94.338188"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4809"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="70.338142"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4811"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4813"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="50.337986" />
-      <rect
-         y="26.338337"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4815"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4817"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="6.3381853" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4819"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-17.661861" />
-      <rect
-         y="-37.662018"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4821"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4823"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-61.661663" />
-      <rect
-         y="-81.661812"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4825"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-105.66186"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4827"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4829"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-125.66202" />
-      <rect
-         y="-149.66167"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4831"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4833"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-169.6618" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4835"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-193.66185" />
-      <rect
-         y="-213.66202"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4837"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-237.66246"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4848"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4851"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-257.66263" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4853"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-281.66266" />
-      <rect
-         y="-301.66281"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4855"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4857"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-325.66266" />
-      <rect
-         y="-345.66281"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4859"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-369.66287"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4861"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4863"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-389.66302" />
-      <rect
-         y="-413.66266"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4865"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4867"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-433.66281" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4869"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-457.66284" />
-      <rect
-         y="-477.66299"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4871"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4873"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-501.66266" />
-      <rect
-         y="-521.66278"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4875"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-545.66284"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4877"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4879"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-565.66302" />
-      <rect
-         y="-589.66266"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4881"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4883"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-609.66278" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4885"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-633.66284" />
-      <rect
-         y="-653.66302"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4887"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4889"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-677.66266" />
-      <rect
-         y="-697.66278"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4891"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-721.66284"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4893"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4895"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-741.66302" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4897"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-765.66327" />
-      <rect
-         y="-785.66345"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4899"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-809.66345"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4901"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4903"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-829.66364" />
-      <rect
-         y="-853.66345"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4905"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4907"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-873.66364" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4909"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-897.6637" />
-      <rect
-         y="-917.66382"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4911"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4913"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-941.66345" />
-      <rect
-         y="-961.66364"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4915"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-985.66364"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4917"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4919"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1005.6638" />
-      <rect
-         y="-1029.6635"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4921"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4923"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1049.6636" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4926"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1073.6637" />
-      <rect
-         y="-1093.6638"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4928"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4930"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1117.6635" />
-      <rect
-         y="-1137.6636"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4932"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-1161.6637"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4934"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4936"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1181.6638" />
-      <rect
-         y="-1205.6635"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4938"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4940"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1225.6636" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4942"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1249.6637" />
-      <rect
-         y="-1269.6638"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4944"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-1293.6641"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4946"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4948"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1313.6642" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4950"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1337.6642" />
-      <rect
-         y="-1357.6644"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4952"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4954"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1381.6642" />
-      <rect
-         y="-1401.6644"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4956"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-1425.6644"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4958"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4960"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1445.6646" />
-      <rect
-         y="-1469.6642"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4962"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4964"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1489.6644" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4966"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1513.6644" />
-      <rect
-         y="-1533.6646"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4968"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4970"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1557.6642" />
-      <rect
-         y="-1577.6643"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4972"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-1601.6644"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4974"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4976"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1621.6646" />
-      <rect
-         y="-1645.6642"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4978"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4980"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1665.6643" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4982"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1689.6644" />
-      <rect
-         y="-1709.6646"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4984"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4986"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1733.6642" />
-      <rect
-         y="-1753.6643"
-         x="-300.81363"
-         height="18.800058"
-         width="18.482372"
-         id="rect4988"
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         y="-1777.6644"
-         x="-300.81439"
-         height="22.800125"
-         width="18.482525"
-         id="rect4990"
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <rect
-         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4992"
-         width="18.482372"
-         height="18.800058"
-         x="-300.81363"
-         y="-1797.6646" />
-      <rect
-         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         id="rect4994"
-         width="18.482525"
-         height="22.800125"
-         x="-300.81439"
-         y="-1821.6649" />
-    </g>
-    <g
-       id="ASI_scale"
-       inkscape:label="#g3847"
-       transform="translate(0.69023445,0)">
-      <g
-         transform="translate(0,-763.04395)"
-         inkscape:label="#g4464"
-         id="ASI_scalenum">
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4347"
-           y="534.31567"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="534.31567"
-             x="91.900978"
-             id="tspan4349"
-             sodipodi:role="line">140</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="408.40027"
-           id="text4361"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4363"
-             x="91.900978"
-             y="408.40027"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">160</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="660.23047"
-           id="text4368"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4370"
-             x="91.900978"
-             y="660.23047"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">120</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4372"
-           y="786.14551"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="786.14551"
-             x="91.900978"
-             id="tspan4374"
-             sodipodi:role="line">100</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="912.06061"
-           id="text4376"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4378"
-             x="91.900978"
-             y="912.06061"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">080</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4380"
-           y="1037.9757"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="1037.9757"
-             x="91.900978"
-             id="tspan4382"
-             sodipodi:role="line">060</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="1163.8907"
-           id="text4384"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4386"
-             x="91.900978"
-             y="1163.8907"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">040</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4388"
-           y="282.4852"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="282.4852"
-             x="91.900978"
-             id="tspan4390"
-             sodipodi:role="line">180</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="156.57011"
-           id="text4392"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4394"
-             x="91.900978"
-             y="156.57011"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">200</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4396"
-           y="30.655033"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="30.655033"
-             x="91.900978"
-             id="tspan4398"
-             sodipodi:role="line">220</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="-95.260048"
-           id="text4400"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4402"
-             x="91.900978"
-             y="-95.260048"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">240</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4404"
-           y="-221.17514"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="-221.17514"
-             x="91.900978"
-             id="tspan4406"
-             sodipodi:role="line">260</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="-347.09021"
-           id="text4408"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4410"
-             x="91.900978"
-             y="-347.09021"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">280</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4412"
-           y="-473.00531"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="-473.00531"
-             x="91.900978"
-             id="tspan4414"
-             sodipodi:role="line">300</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="-598.92041"
-           id="text4416"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4418"
-             x="91.900978"
-             y="-598.92041"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">320</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4420"
-           y="-724.83545"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="-724.83545"
-             x="91.900978"
-             id="tspan4422"
-             sodipodi:role="line">340</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="-850.75055"
-           id="text4424"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4426"
-             x="91.900978"
-             y="-850.75055"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">360</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4428"
-           y="-976.66565"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="-976.66565"
-             x="91.900978"
-             id="tspan4430"
-             sodipodi:role="line">380</tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           x="91.900978"
-           y="-1102.5807"
-           id="text4432"
-           transform="scale(0.95383277,1.0484018)"
-           inkscape:label="#text975"><tspan
-             sodipodi:role="line"
-             id="tspan4434"
-             x="91.900978"
-             y="-1102.5807"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">400</tspan></text>
-        <text
-           inkscape:label="#text975"
-           transform="scale(0.95383277,1.0484018)"
-           id="text4436"
-           y="-1228.4958"
-           x="91.900978"
-           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-             y="-1228.4958"
-             x="91.900978"
-             id="tspan4438"
-             sodipodi:role="line">420</tspan></text>
-      </g>
-      <g
-         transform="translate(0,-763.04395)"
-         inkscape:label="#g4562"
-         id="ASI_scaletick">
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,549.78856 17.06206,0"
-           id="path4359"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4440"
-           d="m 105.17928,615.79362 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,681.79842 17.06206,0"
-           id="path4442"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,747.80322 17.06206,0"
-           id="path4446"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4448"
-           d="m 105.17928,813.80802 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,879.81282 17.06206,0"
-           id="path4450"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4452"
-           d="m 105.17928,945.81762 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,1011.8224 17.06206,0"
-           id="path4454"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4456"
-           d="m 105.17928,1077.8272 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,1143.832 17.06206,0"
-           id="path4458"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4460"
-           d="m 105.17928,1209.8368 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,1275.8416 17.06206,0"
-           id="path4462"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4506"
-           d="m 105.17928,483.78402 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,417.77922 17.06206,0"
-           id="path4508"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4510"
-           d="m 105.17928,351.77442 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,285.76962 17.06206,0"
-           id="path4512"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4514"
-           d="m 105.17928,219.76482 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,153.76002 17.06206,0"
-           id="path4516"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4518"
-           d="m 105.17928,87.755223 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,21.750423 17.06206,0"
-           id="path4520"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4522"
-           d="m 105.17928,-44.254377 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-110.25918 17.06206,0"
-           id="path4524"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4526"
-           d="m 105.17928,-176.26398 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-242.26878 17.06206,0"
-           id="path4528"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4530"
-           d="m 105.17928,-308.27358 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-374.27838 17.06206,0"
-           id="path4532"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4534"
-           d="m 105.17928,-440.28318 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-506.28798 17.06206,0"
-           id="path4536"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4538"
-           d="m 105.17928,-572.29278 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-638.29758 17.06206,0"
-           id="path4540"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4542"
-           d="m 105.17928,-704.30238 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-770.30718 17.06206,0"
-           id="path4544"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4546"
-           d="m 105.17928,-836.31198 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-902.31678 17.06206,0"
-           id="path4548"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4550"
-           d="m 105.17928,-968.32158 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-1034.3264 17.06206,0"
-           id="path4552"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4554"
-           d="m 105.17928,-1100.3312 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-1166.336 17.06206,0"
-           id="path4556"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path4558"
-           d="m 105.17928,-1232.3408 17.06206,0"
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 105.17928,-1298.3456 17.06206,-10e-5"
-           id="path4560"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-      </g>
+       transform="translate(-104.78479,0)"
+       inkscape:label="#g4743"
+       id="HDG_scale">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4456-8"
+         d="m 256.91925,944.75532 0,22.36203"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         x="269.18036"
+         y="958.2016"
+         id="HDG_one"
+         transform="scale(0.95383278,1.0484018)"
+         inkscape:label="#text975"><tspan
+           sodipodi:role="line"
+           id="tspan4386-6"
+           x="269.18036"
+           y="958.2016"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
       <path
          style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 123.76482,-2061.3896 0,2574.1872"
-         id="ASI_line"
+         d="m 651.08597,944.75532 0,22.36203"
+         id="path4691"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <text
+         inkscape:label="#text975"
+         transform="scale(0.95383278,1.0484018)"
+         id="HDG_four"
+         y="958.2016"
+         x="579.11359"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+           y="958.2016"
+           x="579.11359"
+           id="tspan4695"
+           sodipodi:role="line">00</tspan></text>
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 306.19037,944.75532 0,12.35406"
+         id="path4697"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 355.46117,944.75532 0,22.36203"
+         id="path4699"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4701"
+         d="m 454.00277,944.75532 0,22.36203"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4703"
+         d="m 552.54437,944.75532 0,22.36203"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <text
+         inkscape:label="#text975"
+         transform="scale(0.95383278,1.0484018)"
+         id="HDG_two"
+         y="958.2016"
+         x="372.49115"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+           y="958.2016"
+           x="372.49115"
+           id="tspan4707"
+           sodipodi:role="line">00</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         x="475.80234"
+         y="958.2016"
+         id="HDG_three"
+         transform="scale(0.95383278,1.0484018)"
+         inkscape:label="#text975"><tspan
+           sodipodi:role="line"
+           id="tspan4711"
+           x="475.80234"
+           y="958.2016"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         x="682.42474"
+         y="958.2016"
+         id="HDG_five"
+         transform="scale(0.95383278,1.0484018)"
+         inkscape:label="#text975"><tspan
+           sodipodi:role="line"
+           id="tspan4715"
+           x="682.42474"
+           y="958.2016"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4717"
+         d="m 404.73197,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 503.27357,944.75532 0,12.35406"
+         id="path4719"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4721"
+         d="m 601.81517,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4723"
+         d="m 207.64877,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4725"
+         d="m 749.62718,944.75532 0,22.36203"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <text
+         inkscape:label="#text975"
+         transform="scale(0.95383278,1.0484018)"
+         id="HDG_six"
+         y="958.2016"
+         x="785.73553"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+           y="958.2016"
+           x="785.73553"
+           id="tspan4729"
+           sodipodi:role="line">00</tspan></text>
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 700.35638,944.75532 0,12.35406"
+         id="path4731"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 848.16878,944.75532 0,22.36203"
+         id="path4733"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+         x="889.04669"
+         y="958.2016"
+         id="HDG_seven"
+         transform="scale(0.95383278,1.0484018)"
+         inkscape:label="#text975"><tspan
+           sodipodi:role="line"
+           id="tspan4737"
+           x="889.04669"
+           y="958.2016"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.75">00</tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4739"
+         d="m 798.89798,944.75532 0,12.35406"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 897.43958,944.75532 0,12.35406"
+         id="path4741"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
     </g>
+    <rect
+       inkscape:label="#rect4954"
+       y="907.00177"
+       x="443.85849"
+       height="53.319752"
+       width="7.7972717"
+       id="HDG_pointer"
+       style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:4.64450645;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        inkscape:label="#rect902"
        sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
-       id="ASI_target"
-       d="m 155.37613,491.12121 -1e-5,43.41526 -40.47717,-21.70763 z"
+       id="HDG_target"
+       d="m 426.05644,912.48947 43.41526,10e-6 -21.70763,40.47717 z"
        style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <g
-       id="ASI_index"
-       inkscape:label="#g949"
-       transform="matrix(1.0666667,0,0,1.066636,0.69023445,-0.50381959)">
+       transform="matrix(1.0666667,0,0,1.066636,7.9500002,2.8086774)"
+       inkscape:label="#g5019"
+       id="CRS_pointer">
+      <rect
+         style="fill:#b055be;fill-opacity:1;stroke:none;stroke-width:2.79342866;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5013"
+         width="6.1875"
+         height="46.03125"
+         x="409.21875"
+         y="897.6875" />
+      <rect
+         y="-426.51562"
+         x="929.98438"
+         height="28.40625"
+         width="6.1875"
+         id="rect5015"
+         style="fill:#b055be;fill-opacity:1;stroke:none;stroke-width:2.19441199;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(0,1,-1,0,0,0)" />
+    </g>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#08b837;stroke-width:3.86463165;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="TRK_pointer"
+       width="14.344484"
+       height="14.344484"
+       x="966.534"
+       y="194.07515"
+       transform="matrix(0.57965979,0.8148586,-0.57965979,0.8148586,0,0)"
+       inkscape:label="#rect4872" />
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95383278,1.0484018)"
+       id="HDG_digit_L"
+       y="895.6087"
+       x="218.92215"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+         y="895.6087"
+         x="218.92215"
+         id="tspan4386-5"
+         sodipodi:role="line">000</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="721.2049"
+       y="895.61029"
+       id="HDG_digit_R"
+       transform="scale(0.95383443,1.0484)"
+       inkscape:label="#text975"><tspan
+         sodipodi:role="line"
+         id="tspan4786"
+         x="721.2049"
+         y="895.61029"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#179ab7;fill-opacity:1;stroke-width:0.75">000</tspan></text>
+  </g>
+  <rect
+     inkscape:label="#rect9211"
+     y="512.82642"
+     x="8.3655996"
+     height="275.79279"
+     width="117.6912"
+     id="ASI_trend_down_clip"
+     style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     id="ASI_group"
+     inkscape:label="#g4784">
+    <g
+       id="ASI_max"
+       inkscape:label="#g4996"
+       transform="translate(427.21679,200.65901)">
+      <rect
+         y="290.33853"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4786"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4788"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="270.33838" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4794"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="246.33833" />
+      <rect
+         y="226.33818"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4797"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4799"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="202.33833" />
+      <rect
+         y="182.33818"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4801"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="158.33813"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4803"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4805"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="138.33798" />
+      <rect
+         y="114.33834"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4807"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4809"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="94.338188" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4811"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="70.338142" />
+      <rect
+         y="50.337986"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4813"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4815"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="26.338337" />
+      <rect
+         y="6.3381853"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4817"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-17.661861"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4819"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4821"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-37.662018" />
+      <rect
+         y="-61.661663"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4823"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4825"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-81.661812" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4827"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-105.66186" />
+      <rect
+         y="-125.66202"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4829"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4831"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-149.66167" />
+      <rect
+         y="-169.6618"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4833"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-193.66185"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4835"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4837"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-213.66202" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4848"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-237.66246" />
+      <rect
+         y="-257.66263"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4851"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-281.66266"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4853"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4855"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-301.66281" />
+      <rect
+         y="-325.66266"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4857"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4859"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-345.66281" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4861"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-369.66287" />
+      <rect
+         y="-389.66302"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4863"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4865"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-413.66266" />
+      <rect
+         y="-433.66281"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4867"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-457.66284"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4869"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4871"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-477.66299" />
+      <rect
+         y="-501.66266"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4873"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4875"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-521.66278" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4877"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-545.66284" />
+      <rect
+         y="-565.66302"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4879"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4881"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-589.66266" />
+      <rect
+         y="-609.66278"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4883"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-633.66284"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4885"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4887"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-653.66302" />
+      <rect
+         y="-677.66266"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4889"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4891"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-697.66278" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4893"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-721.66284" />
+      <rect
+         y="-741.66302"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4895"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-765.66327"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4897"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4899"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-785.66345" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4901"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-809.66345" />
+      <rect
+         y="-829.66364"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4903"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4905"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-853.66345" />
+      <rect
+         y="-873.66364"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4907"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-897.6637"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4909"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4911"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-917.66382" />
+      <rect
+         y="-941.66345"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4913"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4915"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-961.66364" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4917"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-985.66364" />
+      <rect
+         y="-1005.6638"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4919"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4921"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1029.6635" />
+      <rect
+         y="-1049.6636"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4923"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1073.6637"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4926"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4928"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1093.6638" />
+      <rect
+         y="-1117.6635"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4930"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4932"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1137.6636" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4934"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1161.6637" />
+      <rect
+         y="-1181.6638"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4936"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4938"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1205.6635" />
+      <rect
+         y="-1225.6636"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4940"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1249.6637"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4942"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4944"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1269.6638" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4946"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1293.6641" />
+      <rect
+         y="-1313.6642"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4948"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1337.6642"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4950"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4952"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1357.6644" />
+      <rect
+         y="-1381.6642"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4954"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4956"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1401.6644" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4958"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1425.6644" />
+      <rect
+         y="-1445.6646"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4960"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4962"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1469.6642" />
+      <rect
+         y="-1489.6644"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4964"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1513.6644"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4966"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4968"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1533.6646" />
+      <rect
+         y="-1557.6642"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4970"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4972"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1577.6643" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4974"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1601.6644" />
+      <rect
+         y="-1621.6646"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4976"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4978"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1645.6642" />
+      <rect
+         y="-1665.6643"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4980"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1689.6644"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4982"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4984"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1709.6646" />
+      <rect
+         y="-1733.6642"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4986"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4988"
+         width="18.482372"
+         height="18.800058"
+         x="-300.81363"
+         y="-1753.6643" />
+      <rect
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         id="rect4990"
+         width="18.482525"
+         height="22.800125"
+         x="-300.81439"
+         y="-1777.6644" />
+      <rect
+         y="-1797.6646"
+         x="-300.81363"
+         height="18.800058"
+         width="18.482372"
+         id="rect4992"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19994247;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <rect
+         y="-1821.6649"
+         x="-300.81439"
+         height="22.800125"
+         width="18.482525"
+         id="rect4994"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:1.19987428;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    </g>
+    <g
+       transform="translate(0.69023445,0)"
+       inkscape:label="#g3847"
+       id="ASI_scale">
+      <g
+         id="ASI_scalenum"
+         inkscape:label="#g4464"
+         transform="translate(0,-763.04395)">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="534.31567"
+           id="text4347"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4349"
+             x="91.900978"
+             y="534.31567"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">140</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4361"
+           y="408.40027"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="408.40027"
+             x="91.900978"
+             id="tspan4363"
+             sodipodi:role="line">160</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4368"
+           y="660.23047"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="660.23047"
+             x="91.900978"
+             id="tspan4370"
+             sodipodi:role="line">120</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="786.14551"
+           id="text4372"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4374"
+             x="91.900978"
+             y="786.14551"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">100</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4376"
+           y="912.06061"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="912.06061"
+             x="91.900978"
+             id="tspan4378"
+             sodipodi:role="line">080</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="1037.9757"
+           id="text4380"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4382"
+             x="91.900978"
+             y="1037.9757"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">060</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4384"
+           y="1163.8907"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="1163.8907"
+             x="91.900978"
+             id="tspan4386"
+             sodipodi:role="line">040</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="282.4852"
+           id="text4388"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4390"
+             x="91.900978"
+             y="282.4852"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">180</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4392"
+           y="156.57011"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="156.57011"
+             x="91.900978"
+             id="tspan4394"
+             sodipodi:role="line">200</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="30.655033"
+           id="text4396"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4398"
+             x="91.900978"
+             y="30.655033"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">220</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4400"
+           y="-95.260048"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="-95.260048"
+             x="91.900978"
+             id="tspan4402"
+             sodipodi:role="line">240</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="-221.17514"
+           id="text4404"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4406"
+             x="91.900978"
+             y="-221.17514"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">260</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4408"
+           y="-347.09021"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="-347.09021"
+             x="91.900978"
+             id="tspan4410"
+             sodipodi:role="line">280</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="-473.00531"
+           id="text4412"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4414"
+             x="91.900978"
+             y="-473.00531"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">300</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4416"
+           y="-598.92041"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="-598.92041"
+             x="91.900978"
+             id="tspan4418"
+             sodipodi:role="line">320</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="-724.83545"
+           id="text4420"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4422"
+             x="91.900978"
+             y="-724.83545"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">340</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4424"
+           y="-850.75055"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="-850.75055"
+             x="91.900978"
+             id="tspan4426"
+             sodipodi:role="line">360</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="-976.66565"
+           id="text4428"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4430"
+             x="91.900978"
+             y="-976.66565"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">380</tspan></text>
+        <text
+           inkscape:label="#text975"
+           transform="scale(0.95383277,1.0484018)"
+           id="text4432"
+           y="-1102.5807"
+           x="91.900978"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75"
+             y="-1102.5807"
+             x="91.900978"
+             id="tspan4434"
+             sodipodi:role="line">400</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+           x="91.900978"
+           y="-1228.4958"
+           id="text4436"
+           transform="scale(0.95383277,1.0484018)"
+           inkscape:label="#text975"><tspan
+             sodipodi:role="line"
+             id="tspan4438"
+             x="91.900978"
+             y="-1228.4958"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ffffff;fill-opacity:1;stroke-width:0.75">420</tspan></text>
+      </g>
+      <g
+         id="ASI_scaletick"
+         inkscape:label="#g4562"
+         transform="translate(0,-763.04395)">
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4359"
+           d="m 105.17928,549.78856 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,615.79362 17.06206,0"
+           id="path4440"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4442"
+           d="m 105.17928,681.79842 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4446"
+           d="m 105.17928,747.80322 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,813.80802 17.06206,0"
+           id="path4448"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4450"
+           d="m 105.17928,879.81282 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,945.81762 17.06206,0"
+           id="path4452"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4454"
+           d="m 105.17928,1011.8224 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,1077.8272 17.06206,0"
+           id="path4456"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4458"
+           d="m 105.17928,1143.832 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,1209.8368 17.06206,0"
+           id="path4460"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4462"
+           d="m 105.17928,1275.8416 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,483.78402 17.06206,0"
+           id="path4506"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4508"
+           d="m 105.17928,417.77922 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,351.77442 17.06206,0"
+           id="path4510"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4512"
+           d="m 105.17928,285.76962 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,219.76482 17.06206,0"
+           id="path4514"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4516"
+           d="m 105.17928,153.76002 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,87.755223 17.06206,0"
+           id="path4518"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4520"
+           d="m 105.17928,21.750423 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-44.254377 17.06206,0"
+           id="path4522"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4524"
+           d="m 105.17928,-110.25918 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-176.26398 17.06206,0"
+           id="path4526"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4528"
+           d="m 105.17928,-242.26878 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-308.27358 17.06206,0"
+           id="path4530"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4532"
+           d="m 105.17928,-374.27838 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-440.28318 17.06206,0"
+           id="path4534"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4536"
+           d="m 105.17928,-506.28798 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-572.29278 17.06206,0"
+           id="path4538"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4540"
+           d="m 105.17928,-638.29758 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-704.30238 17.06206,0"
+           id="path4542"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4544"
+           d="m 105.17928,-770.30718 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-836.31198 17.06206,0"
+           id="path4546"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4548"
+           d="m 105.17928,-902.31678 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-968.32158 17.06206,0"
+           id="path4550"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4552"
+           d="m 105.17928,-1034.3264 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-1100.3312 17.06206,0"
+           id="path4554"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4556"
+           d="m 105.17928,-1166.336 17.06206,0"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+           d="m 105.17928,-1232.3408 17.06206,0"
+           id="path4558"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4560"
+           d="m 105.17928,-1298.3456 17.06206,-10e-5"
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      </g>
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path930"
-         d="m 92.069682,481.26097 42.765978,0"
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:4.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path928"
-         d="m 139.62834,491.54141 0,-20.391 -17.13886,10.1955 z"
-         style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:2.71116304;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         inkscape:label="#path905" />
+         id="ASI_line"
+         d="m 123.76482,-2061.3896 0,2574.1872"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 155.37613,491.12121 -1e-5,43.41526 -40.47717,-21.70763 z"
+       id="ASI_target"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:label="#rect902" />
+    <g
+       transform="matrix(1.0666667,0,0,1.066636,0.69023445,-0.50381959)"
+       inkscape:label="#g949"
+       id="ASI_index">
       <path
          style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:4.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 2.3529052,481.26097 6.5316019,0"
+         d="m 92.069682,481.26097 42.765978,0"
+         id="path930"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:label="#path905"
+         style="fill:#c9d121;fill-opacity:1;stroke:none;stroke-width:2.71116304;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 139.62834,491.54141 0,-20.391 -17.13886,10.1955 z"
+         id="path928"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
          id="path944"
+         d="m 2.3529052,481.26097 6.5316019,0"
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:4.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    </g>
+    <g
+       id="ASI_trend_up"
+       inkscape:label="#g4874">
+      <path
+         inkscape:label="#path4632"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4632"
+         d="m 102.47083,892.24236 0,-377.61127"
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4642"
+         d="M 91.191843,534.39032 102.47104,513.68716"
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 113.75024,534.39032 -11.2792,-20.70316"
+         id="path4644"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
     </g>
     <g
        inkscape:label="#g4874"
-       id="ASI_trend_up">
+       id="ASI_trend_down"
+       transform="matrix(1,0,0,-1,0,1025.6524)">
       <path
          style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="m 102.47083,892.24236 0,-377.61127"
-         id="path4632"
+         id="path4886"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc"
          inkscape:label="#path4632" />
       <path
          style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="M 91.191843,534.39032 102.47104,513.68716"
-         id="path4642"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4644"
-         d="m 113.75024,534.39032 -11.2792,-20.70316"
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    </g>
-    <g
-       transform="matrix(1,0,0,-1,0,1025.6524)"
-       id="ASI_trend_down"
-       inkscape:label="#g4874">
-      <path
-         inkscape:label="#path4632"
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path4886"
-         d="m 102.47083,892.24236 0,-377.61127"
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
          id="path4888"
-         d="M 91.191843,534.39032 102.47104,513.68716"
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 113.75024,534.39032 -11.2792,-20.70316"
-         id="path4890"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4890"
+         d="m 113.75024,534.39032 -11.2792,-20.70316"
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="69.848434"
+       y="835.1153"
+       id="ASI_mach"
+       transform="scale(0.95383277,1.0484018)"
+       inkscape:label="#text975"><tspan
+         sodipodi:role="line"
+         id="tspan4664"
+         x="69.848434"
+         y="835.1153"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75">000</tspan></text>
     <text
        inkscape:label="#text975"
        transform="scale(0.95383277,1.0484018)"
-       id="ASI_mach"
+       id="ASI_mach_decimal"
        y="835.1153"
-       x="69.848434"
+       x="51.798809"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
        xml:space="preserve"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
          y="835.1153"
-         x="69.848434"
-         id="tspan4664"
-         sodipodi:role="line">000</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="51.798809"
-       y="835.1153"
-       id="ASI_mach_decimal"
-       transform="scale(0.95383277,1.0484018)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan4668"
          x="51.798809"
-         y="835.1153"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48.8348px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75">.</tspan></text>
-    <text
-       inkscape:label="#text975"
-       transform="scale(0.95382555,1.0484097)"
-       id="ASI_digit_DN"
-       y="787.28491"
-       x="95.148567"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
-         y="787.28491"
-         x="95.148567"
-         id="tspan4686"
-         sodipodi:role="line">000</tspan></text>
+         id="tspan4668"
+         sodipodi:role="line">.</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
        x="95.148567"
-       y="220.32645"
-       id="ASI_digit_UP"
-       transform="scale(0.95382558,1.0484097)"
+       y="787.28491"
+       id="ASI_digit_DN"
+       transform="scale(0.95382555,1.0484097)"
        inkscape:label="#text975"><tspan
          sodipodi:role="line"
-         id="tspan4690"
+         id="tspan4686"
          x="95.148567"
-         y="220.32645"
+         y="787.28491"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">000</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="80.506805"
-       y="787.28491"
-       id="ASI_decimal_DN"
-       transform="scale(0.95382558,1.0484097)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan4691"
-         x="80.506805"
-         y="787.28491"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">.</tspan></text>
-    <text
        inkscape:label="#text975"
        transform="scale(0.95382558,1.0484097)"
-       id="ASI_decimal_UP"
+       id="ASI_digit_UP"
        y="220.32645"
-       x="80.506668"
+       x="95.148567"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
        xml:space="preserve"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
          y="220.32645"
-         x="80.506668"
-         id="tspan4696"
+         x="95.148567"
+         id="tspan4690"
+         sodipodi:role="line">000</tspan></text>
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95382558,1.0484097)"
+       id="ASI_decimal_DN"
+       y="787.28491"
+       x="80.506805"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+         y="787.28491"
+         x="80.506805"
+         id="tspan4691"
          sodipodi:role="line">.</tspan></text>
-  </g>
-  <g
-     inkscape:label="#g4779"
-     id="ASI_error">
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#f80000;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="118.56967"
-       y="505.46484"
-       id="text4384-2"
-       transform="scale(0.95383278,1.0484018)"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+       x="80.506668"
+       y="220.32645"
+       id="ASI_decimal_UP"
+       transform="scale(0.95382558,1.0484097)"
        inkscape:label="#text975"><tspan
          sodipodi:role="line"
-         id="tspan4386-4"
-         x="118.56967"
-         y="505.46484"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#f80000;fill-opacity:1;stroke-width:0.75">SPD</tspan></text>
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 124.45518,236.9723 0,552.07397"
-       id="ASI_line_red"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc"
-       inkscape:label="#ASI_line-8" />
+         id="tspan4696"
+         x="80.506668"
+         y="220.32645"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">.</tspan></text>
   </g>
   <g
-     inkscape:label="#g4757"
-     id="ASI_frame">
+     id="ASI_error"
+     inkscape:label="#g4779">
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95383278,1.0484018)"
+       id="text4384-2"
+       y="505.46484"
+       x="118.56967"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#f80000;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#f80000;fill-opacity:1;stroke-width:0.75"
+         y="505.46484"
+         x="118.56967"
+         id="tspan4386-4"
+         sodipodi:role="line">SPD</tspan></text>
     <path
-       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 13.168124,235.4451 141.300716,0"
-       id="rect919"
+       inkscape:label="#ASI_line-8"
+       sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       id="ASI_line_red"
+       d="m 124.45518,236.9723 0,552.07397"
+       style="fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+  </g>
+  <g
+     id="ASI_frame"
+     inkscape:label="#g4757">
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path922"
-       d="m 13.167811,790.62913 141.300719,0"
+       id="rect919"
+       d="m 13.168124,235.4451 141.300716,0"
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995403;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 13.167811,790.62913 141.300719,0"
+       id="path922"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
   </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="463.77478"
-     y="503.59891"
-     id="AI_error"
-     transform="scale(0.95383278,1.0484018)"
-     inkscape:label="#text975"><tspan
-       sodipodi:role="line"
-       id="tspan4386-4-1"
-       x="463.77478"
-       y="503.59891"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:56px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75">ATT</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="851.70166"
-     y="505.93329"
-     id="ALT_error"
-     transform="scale(0.95383278,1.0484018)"
-     inkscape:label="#text975"><tspan
-       sodipodi:role="line"
-       id="tspan4386-4-0"
-       x="851.70166"
-       y="505.93329"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75">ALT</tspan></text>
   <text
      inkscape:label="#text975"
      transform="scale(0.95383278,1.0484018)"
-     id="VS_error"
-     y="445.50174"
-     x="1029.0986"
+     id="AI_error"
+     y="503.59891"
+     x="463.77478"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:56px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
+       y="503.59891"
+       x="463.77478"
+       id="tspan4386-4-1"
+       sodipodi:role="line">ATT</tspan></text>
+  <text
+     inkscape:label="#text975"
+     transform="scale(0.95383278,1.0484018)"
+     id="ALT_error"
+     y="505.93329"
+     x="851.70166"
      style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
      xml:space="preserve"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
-       y="445.50174"
-       x="1029.0986"
-       id="tspan4386-4-0-2"
-       sodipodi:role="line">V</tspan><tspan
-       id="tspan4813"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
-       y="505.50174"
-       x="1029.0986"
-       sodipodi:role="line">/</tspan><tspan
-       id="tspan4815"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
-       y="565.50171"
-       x="1029.0986"
-       sodipodi:role="line">S</tspan></text>
+       y="505.93329"
+       x="851.70166"
+       id="tspan4386-4-0"
+       sodipodi:role="line">ALT</tspan></text>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="522.40784"
-     y="950.08264"
-     id="HDG_error"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="1029.0986"
+     y="445.50174"
+     id="VS_error"
      transform="scale(0.95383278,1.0484018)"
      inkscape:label="#text975"><tspan
        sodipodi:role="line"
-       id="tspan4386-4-5"
-       x="522.40784"
-       y="950.08264"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ff0000;fill-opacity:1;stroke-width:0.75">HDG</tspan></text>
+       id="tspan4386-4-0-2"
+       x="1029.0986"
+       y="445.50174"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75">V</tspan><tspan
+       sodipodi:role="line"
+       x="1029.0986"
+       y="505.50174"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
+       id="tspan4813">/</tspan><tspan
+       sodipodi:role="line"
+       x="1029.0986"
+       y="565.50171"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
+       id="tspan4815">S</tspan></text>
   <text
-     inkscape:label="#text1607"
-     id="machError"
-     y="874.4469"
-     x="34.684372"
-     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     inkscape:label="#text975"
+     transform="scale(0.95383278,1.0484018)"
+     id="HDG_error"
+     y="950.08264"
+     x="522.40784"
+     style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.75"
      xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#ff0000;fill-opacity:1;stroke-width:0.75"
-       y="874.4469"
-       x="34.684372"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:end;text-anchor:end;fill:#ff0000;fill-opacity:1;stroke-width:0.75"
+       y="950.08264"
+       x="522.40784"
+       id="tspan4386-4-5"
+       sodipodi:role="line">HDG</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="34.684372"
+     y="874.4469"
+     id="machError"
+     inkscape:label="#text1607"><tspan
+       sodipodi:role="line"
        id="tspan1605"
-       sodipodi:role="line">MACH</tspan></text>
+       x="34.684372"
+       y="874.4469"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:48px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#ff0000;fill-opacity:1;stroke-width:0.75">MACH</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="663.17761"
+     y="856.17841"
+     id="ilsError"
+     inkscape:label="#text1608"><tspan
+       sodipodi:role="line"
+       id="tspan773"
+       x="663.17761"
+       y="856.17841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#bb6100;fill-opacity:1;stroke-width:0.75">ILS</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="34.684372"
+     y="935.95209"
+     id="ils_code"><tspan
+       sodipodi:role="line"
+       id="tspan978"
+       x="34.684372"
+       y="935.95209"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75">ILS</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="34.684372"
+     y="974.72784"
+     id="ils_freq"><tspan
+       sodipodi:role="line"
+       id="tspan979"
+       x="34.684372"
+       y="974.72784"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75">000.00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="34.684372"
+     y="1013.5292"
+     id="dme_dist"><tspan
+       sodipodi:role="line"
+       id="tspan780"
+       x="34.684372"
+       y="1013.5292"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75">0.0</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="116.45473"
+     y="1014.0706"
+     id="dme_dist_legend"
+     inkscape:label="#dme_dist-5"><tspan
+       sodipodi:role="line"
+       id="tspan780-3"
+       x="116.45473"
+       y="1014.0706"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#179ab7;fill-opacity:1;stroke-width:0.75">NM</tspan></text>
+  <g
+     id="ILS_HDG_L"
+     inkscape:label="#g4757"
+     transform="translate(6.4446604,0.08043884)">
+    <rect
+       y="970.26117"
+       x="170.52216"
+       height="43.153526"
+       width="70.482529"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3.19995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       id="rect791" />
+    <text
+       id="ILS_left"
+       y="960.26117"
+       x="216.52216"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"
+       transform="scale(0.95383278,1.0484018)"
+       inkscape:label="#text979"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke-width:0.75"
+         y="960.26117"
+         x="216.52216"
+         id="tspan793"
+         sodipodi:role="line">000</tspan></text>
+  </g>
+  <g
+     id="ILS_HDG_R"
+     inkscape:label="#g4757"
+     transform="translate(-4.971921,0.08077669)">
+    <rect
+       y="970.26117"
+       x="653.07788"
+       height="43.153526"
+       width="70.482529"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3.19995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       id="rect797" />
+    <text
+       id="ILS_right"
+       y="960.26117"
+       x="722.07782"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"
+       transform="scale(0.95383278,1.0484018)"
+       inkscape:label="#text979"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke-width:0.75"
+         y="960.26117"
+         x="722.07782"
+         id="tspan799"
+         sodipodi:role="line">000</tspan></text>
+  </g>
   <text
      inkscape:label="#text1608"
-     id="ilsError"
-     y="856.17841"
-     x="663.17761"
+     id="middleMarker"
+     y="798.61102"
+     x="656.89722"
      style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:0.75"
      xml:space="preserve"><tspan
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#bb6100;fill-opacity:1;stroke-width:0.75"
-       y="856.17841"
-       x="663.17761"
-       id="tspan773"
-       sodipodi:role="line">ILS</tspan></text>
-  <text
-     id="ils_code"
-     y="935.95209"
-     x="34.684372"
-     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75"
-       y="935.95209"
-       x="34.684372"
-       id="tspan978"
-       sodipodi:role="line">ILS</tspan></text>
-  <text
-     id="ils_freq"
-     y="974.72784"
-     x="34.684372"
-     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75"
-       y="974.72784"
-       x="34.684372"
-       id="tspan979"
-       sodipodi:role="line">000.00</tspan></text>
-  <text
-     id="dme_dist"
-     y="1013.5292"
-     x="34.684372"
-     style="font-style:normal;font-weight:normal;font-size:38.99px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
-     xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:38.99px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#b055be;fill-opacity:1;stroke-width:0.75"
-       y="1013.5292"
-       x="34.684372"
-       id="tspan780"
-       sodipodi:role="line">0.0</tspan></text>
-  <text
-     inkscape:label="#dme_dist-5"
-     id="dme_dist_legend"
-     y="1014.0706"
-     x="116.45473"
-     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-     xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#179ab7;fill-opacity:1;stroke-width:0.75"
-       y="1014.0706"
-       x="116.45473"
-       id="tspan780-3"
-       sodipodi:role="line">NM</tspan></text>
-  <g
-     transform="translate(6.4446604,0.08043884)"
-     inkscape:label="#g4757"
-     id="ILS_HDG_L">
-    <rect
-       id="rect791"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3.19995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       width="70.482529"
-       height="43.153526"
-       x="170.52216"
-       y="970.26117" />
-    <text
-       inkscape:label="#text979"
-       transform="scale(0.95383278,1.0484018)"
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="216.52216"
-       y="960.26117"
-       id="ILS_left"><tspan
-         sodipodi:role="line"
-         id="tspan793"
-         x="216.52216"
-         y="960.26117"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke-width:0.75">000</tspan></text>
-  </g>
-  <g
-     transform="translate(-4.971921,0.08077669)"
-     inkscape:label="#g4757"
-     id="ILS_HDG_R">
-    <rect
-       id="rect797"
-       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:3.19995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       width="70.482529"
-       height="43.153526"
-       x="653.07788"
-       y="970.26117" />
-    <text
-       inkscape:label="#text979"
-       transform="scale(0.95383278,1.0484018)"
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="722.07782"
-       y="960.26117"
-       id="ILS_right"><tspan
-         sodipodi:role="line"
-         id="tspan799"
-         x="722.07782"
-         y="960.26117"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#b055be;fill-opacity:1;stroke-width:0.75">000</tspan></text>
-  </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#bb6100;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="656.89722"
-     y="798.61102"
-     id="middleMarker"
-     inkscape:label="#text1608"><tspan
-       sodipodi:role="line"
-       id="tspan773-3"
-       x="656.89722"
        y="798.61102"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#bb6100;fill-opacity:1;stroke-width:0.75">MM</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="659.10315"
-     y="798.60431"
-     id="outerMarker"
-     inkscape:label="#text1608"><tspan
-       sodipodi:role="line"
-       id="tspan773-9"
-       x="659.10315"
-       y="798.60431"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#179ab7;fill-opacity:1;stroke-width:0.75">OM</tspan></text>
+       x="656.89722"
+       id="tspan773-3"
+       sodipodi:role="line">MM</tspan></text>
   <text
      inkscape:label="#text1608"
-     id="innerMarker"
-     y="798.52075"
-     x="680.1095"
-     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+     id="outerMarker"
+     y="798.60431"
+     x="659.10315"
+     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
      xml:space="preserve"><tspan
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#ffffff;fill-opacity:1;stroke-width:0.75"
-       y="798.52075"
-       x="680.1095"
-       id="tspan773-9-9"
-       sodipodi:role="line">IM</tspan></text>
-  <g
-     inkscape:label="#g5173"
-     id="ALT_box_flash">
-    <path
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       id="rect953"
-       d="m 856.4002,481.90842 2.2e-4,-15.92813 h 52.07464 v 93.34657 h -52.07457 v -15.26583"
-       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path951"
-       d="m 770.31078,481.90873 86.08971,-3.1e-4"
-       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <path
-       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 770.31078,544.06163 86.08971,-6e-4"
-       id="path958"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-  </g>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+       y="798.60431"
+       x="659.10315"
+       id="tspan773-9"
+       sodipodi:role="line">OM</tspan></text>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-     x="143.095"
-     y="263.52979"
-     id="v1_text"
-     transform="scale(0.95382559,1.0484097)"
-     inkscape:label="#text975"><tspan
+     style="font-style:normal;font-weight:normal;font-size:30px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75"
+     x="680.1095"
+     y="798.52075"
+     id="innerMarker"
+     inkscape:label="#text1608"><tspan
        sodipodi:role="line"
-       id="tspan4690-5"
-       x="143.095"
-       y="263.52979"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">000</tspan></text>
+       id="tspan773-9-9"
+       x="680.1095"
+       y="798.52075"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';fill:#ffffff;fill-opacity:1;stroke-width:0.75">IM</tspan></text>
   <g
-     transform="translate(0,132.03033)"
-     id="v1_group">
+     id="ALT_box_flash"
+     inkscape:label="#g5173">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 856.4002,481.90842 2.2e-4,-15.92813 h 52.07464 v 93.34657 h -52.07457 v -15.26583"
+       id="rect953"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 770.31078,481.90873 86.08971,-3.1e-4"
+       id="path951"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path4458-3"
-       d="m 105.87037,380.78738 h 34.99469"
-       style="fill:#179ab7;fill-opacity:1;stroke:#179ab7;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="155.31981"
-       y="378.22144"
-       id="v1_digit"
-       transform="scale(0.95382559,1.0484097)"
-       inkscape:label="#text975"><tspan
-         sodipodi:role="line"
-         id="tspan4690-5-6"
-         x="155.31981"
-         y="378.22144"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75">1</tspan></text>
+       id="path958"
+       d="m 770.31078,544.06163 86.08971,-6e-4"
+       style="fill:none;fill-opacity:1;stroke:#ffff00;stroke-width:6;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
   </g>
-  <path
-     sodipodi:nodetypes="zzzzz"
-     inkscape:connector-curvature="0"
-     id="vr_speed"
-     d="m 130.43188,519.13081 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
-     style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:2.39997;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <text
+     inkscape:label="#text975"
+     transform="scale(0.95382559,1.0484097)"
+     id="v1_text"
+     y="263.52979"
+     x="143.095"
+     style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+       y="263.52979"
+       x="143.095"
+       id="tspan4690-5"
+       sodipodi:role="line">000</tspan></text>
   <g
-     id="S_target"
-     transform="translate(-110.76039,-61.624594)">
+     id="v1_group"
+     transform="translate(0,132.03033)">
     <path
-       style="fill:#0dc04b;fill-opacity:1;stroke:#0dc04b;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="m 216.63546,574.48676 h 34.99469"
-       id="path4458-3-5"
+       style="fill:#179ab7;fill-opacity:1;stroke:#179ab7;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 105.87037,380.78738 h 34.99469"
+       id="path4458-3"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <text
        inkscape:label="#text975"
        transform="scale(0.95382559,1.0484097)"
-       id="s_digit"
-       y="562.97687"
-       x="271.44699"
-       style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       id="v1_digit"
+       y="378.22144"
+       x="155.31981"
+       style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke:none;stroke-width:0.75"
        xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
-         y="562.97687"
-         x="271.44699"
-         id="tspan4690-5-6-6"
-         sodipodi:role="line">S</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#179ab7;fill-opacity:1;stroke-width:0.75"
+         y="378.22144"
+         x="155.31981"
+         id="tspan4690-5-6"
+         sodipodi:role="line">1</tspan></text>
   </g>
+  <path
+     style="fill:none;fill-opacity:1;stroke:#179ab7;stroke-width:2.39997;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 130.43188,519.13081 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
+     id="vr_speed"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="zzzzz" />
   <g
-     id="F_target"
-     transform="translate(-174.19974,-101.9011)">
+     transform="translate(-110.76039,-61.624594)"
+     id="S_target">
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path4458-3-5-3"
-       d="m 279.99405,614.73645 h 34.99469"
+       id="path4458-3-5"
+       d="m 216.63546,574.48676 h 34.99469"
        style="fill:#0dc04b;fill-opacity:1;stroke:#0dc04b;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
-       x="337.87274"
-       y="601.36804"
-       id="f_digit"
+       x="271.44699"
+       y="562.97687"
+       id="s_digit"
        transform="scale(0.95382559,1.0484097)"
        inkscape:label="#text975"><tspan
          sodipodi:role="line"
-         id="tspan4690-5-6-6-8"
-         x="337.87274"
+         id="tspan4690-5-6-6"
+         x="271.44699"
+         y="562.97687"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75">S</tspan></text>
+  </g>
+  <g
+     transform="translate(-174.19974,-101.9011)"
+     id="F_target">
+    <path
+       style="fill:#0dc04b;fill-opacity:1;stroke:#0dc04b;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 279.99405,614.73645 h 34.99469"
+       id="path4458-3-5-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       inkscape:label="#text975"
+       transform="scale(0.95382559,1.0484097)"
+       id="f_digit"
+       y="601.36804"
+       x="337.87274"
+       style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:0.75"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75"
          y="601.36804"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;text-anchor:start;fill:#0dc04b;fill-opacity:1;stroke-width:0.75">F</tspan></text>
+         x="337.87274"
+         id="tspan4690-5-6-6-8"
+         sodipodi:role="line">F</tspan></text>
   </g>
   <g
      id="flap_max">
     <path
-       style="fill:#bb6100;fill-opacity:1;stroke:#bb6100;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-       d="M 105.66652,509.6484 H 121.2338"
-       id="path5236"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
-       id="path5236-4"
-       d="m 105.69059,516.04573 h 15.56728"
+       id="path5236"
+       d="M 105.66652,509.6484 H 121.2338"
        style="fill:#bb6100;fill-opacity:1;stroke:#bb6100;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+    <path
+       style="fill:#bb6100;fill-opacity:1;stroke:#bb6100;stroke-width:3.20025;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 105.69059,516.04573 h 15.56728"
+       id="path5236-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
   </g>
   <path
-     style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:2.39997;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 124.55535,519.10569 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
-     id="clean_speed"
+     sodipodi:nodetypes="zzzzz"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="zzzzz" />
+     id="clean_speed"
+     d="m 124.55535,519.10569 c -3.51657,0 -6.36731,-2.85066 -6.36731,-6.36712 0,-3.51646 2.85073,-6.36713 6.36731,-6.36713 3.51658,0 6.36732,2.85066 6.36732,6.36713 0,3.51648 -2.85075,6.36712 -6.36732,6.36712 z"
+     style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:2.39997;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <g
-     style="stroke:#bb6100;stroke-width:3.20031476;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:label="#g5173"
      id="ALT_box_amber"
-     inkscape:label="#g5173">
+     style="stroke:#bb6100;stroke-width:3.20031476;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
     <g
-       id="alt-box-group"
-       inkscape:label="alt-box-group">
+       inkscape:label="alt-box-group"
+       id="alt-box-group">
       <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path1652"
+         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
          d="m 856.4002,481.90842 2.2e-4,-15.92813 h 52.07464 v 93.34657 h -52.07457 v -15.26583"
-         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="path1652"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 770.31078,481.90873 86.08971,-3.1e-4"
+         id="path1654"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
       <path
          sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         id="path1654"
-         d="m 770.31078,481.90873 86.08971,-3.1e-4"
-         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 770.31078,544.06163 86.08971,-6e-4"
          id="path1656"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc" />
+         d="m 770.31078,544.06163 86.08971,-6e-4"
+         style="fill:none;fill-opacity:1;stroke:#bb6100;stroke-width:3.20031476;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke" />
     </g>
   </g>
+  <text
+     transform="scale(0.87678236,1.1405339)"
+     id="FMA_flxmode"
+     y="74.429939"
+     x="61.095329"
+     style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.657577"
+     xml:space="preserve"
+     inkscape:label="#text983"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577"
+       y="74.429939"
+       x="61.095329"
+       id="tspan4307-3"
+       sodipodi:role="line">FLX</tspan></text>
 </svg>


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
- fix FLX formatting (removes empty characters on Mac)
- add support for 0-99 heading entry on ILS CRS (spacing was previously odd)

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
