### PR TITLE
Correct v-speed behavior + mcdu changes for pfd

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1917,6 +1917,7 @@
 			<file>Aircraft/A320-family/Nasal/MCDU/PERFCLB.nas</file>
 			<file>Aircraft/A320-family/Nasal/MCDU/PERFCRZ.nas</file>
 			<file>Aircraft/A320-family/Nasal/MCDU/PERFDES.nas</file>
+			<file>Aircraft/A320-family/Nasal/MCDU/PERFGA.nas</file>
 			<file>Aircraft/A320-family/Nasal/MCDU/PERFTO.nas</file>
 			<file>Aircraft/A320-family/Nasal/MCDU/RADNAV.nas</file>
 			<file>Aircraft/A320-family/Nasal/MCDU/DATA.nas</file>

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -80,6 +80,12 @@ var vr = props.globals.getNode("FMGC/internal/vr", 1);
 var vrSet = props.globals.getNode("FMGC/internal/vr-set", 1);
 var v2 = props.globals.getNode("FMGC/internal/v2", 1);
 var v2Set = props.globals.getNode("FMGC/internal/v2-set", 1);
+var f_speed = props.globals.getNode("FMGC/internal/f-speed", 1);
+var s_speed = props.globals.getNode("FMGC/internal/s-speed", 1);
+var o_speed = props.globals.getNode("FMGC/internal/o-speed", 1);
+var min_speed = props.globals.getNode("FMGC/internal/minspeed", 1);
+#var vapp_speed = props.globals.getNode("FMGC/internal/vapp-speed", 1);
+var altitude = props.globals.getNode("instrumentation/altimeter/indicated-altitude-ft", 1);
 var clbReducFt = props.globals.getNode("systems/thrust/clbreduc-ft", 1);
 var reducFt = props.globals.getNode("FMGC/internal/reduc-agl-ft", 1); # It's not AGL anymore
 var thrAccSet = props.globals.getNode("MCDUC/thracc-set", 1);
@@ -1234,6 +1240,7 @@ var canvas_MCDU_base = {
 				
 				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);
+				me.fontSizeCenter(small, small, small, 0, 0, 0);
 				
 				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
 				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
@@ -1319,9 +1326,29 @@ var canvas_MCDU_base = {
 			me["Simple_R4S"].setText("FLEX TO TEMP");
 			me["Simple_R5S"].setText("ENG OUT ACC");
 			me["Simple_R6S"].setText("NEXT ");
-			me["Simple_C1"].setText(" ---");
-			me["Simple_C2"].setText(" ---");
-			me["Simple_C3"].setText(" ---");
+			
+			if (zfwSet.getValue() == 1 and blockSet.getValue() == 1) {
+				lbs1000 = KG2LB * num(zfw.getValue() + block.getValue());
+				
+				tgt_f = ((0.4352 * lbs1000) + 51.006) * 1.47;
+				setprop("FMGC/internal/f-speed", tgt_f);
+				tgt_s = ((0.0024 * lbs1000 * lbs1000) + (0.124 * lbs1000) + 88.942) * 1.23;
+				setprop("FMGC/internal/s-speed", tgt_s);
+				tgt_clean = 2 * lbs1000 * 0.45359237 + 85;
+				if (altitude.getValue() > 20000) {
+					tgt_clean += (altitude.getValue() - 20000) / 1000;
+				}
+				setprop("FMGC/internal/o-speed", tgt_clean);
+				
+				me["Simple_C1"].setText(sprintf("%3.0f", f_speed.getValue()));
+				me["Simple_C2"].setText(sprintf("%3.0f", s_speed.getValue()));
+				me["Simple_C3"].setText(sprintf("%3.0f", o_speed.getValue()));
+			} else {
+				me["Simple_C1"].setText(" ---");
+				me["Simple_C2"].setText(" ---");
+				me["Simple_C3"].setText(" ---");
+			}
+			
 			me["Simple_C1S"].setText("FLP RETR");
 			me["Simple_C2S"].setText("SLT RETR");
 			me["Simple_C3S"].setText("CLEAN  ");
@@ -1434,10 +1461,31 @@ var canvas_MCDU_base = {
 			me["Simple_R3S"].setText("DH");
 			me["Simple_R4S"].setText("LDG CONF");
 			me["Simple_R6S"].setText("NEXT ");
-			me["Simple_C1"].setText(" ---");
-			me["Simple_C2"].setText(" ---");
-			me["Simple_C3"].setText(" ---");
-			me["Simple_C5"].setText(" ---");
+			
+			if (zfwSet.getValue() == 1 and blockSet.getValue() == 1) {
+				lbs1000 = KG2LB * num(zfw.getValue() + block.getValue());
+				
+				tgt_f = ((0.4352 * lbs1000) + 51.006) * 1.47;
+				setprop("FMGC/internal/f-speed", tgt_f);
+				tgt_s = ((0.0024 * lbs1000 * lbs1000) + (0.124 * lbs1000) + 88.942) * 1.23;
+				setprop("FMGC/internal/s-speed", tgt_s);
+				tgt_clean = 2 * lbs1000 * 0.45359237 + 85;
+				if (altitude.getValue() > 20000) {
+					tgt_clean += (altitude.getValue() - 20000) / 1000;
+				}
+				setprop("FMGC/internal/o-speed", tgt_clean);
+				
+				me["Simple_C1"].setText(sprintf("%3.0f", f_speed.getValue()));
+				me["Simple_C2"].setText(sprintf("%3.0f", s_speed.getValue()));
+				me["Simple_C3"].setText(sprintf("%3.0f", o_speed.getValue()));
+				me["Simple_C5"].setText(sprintf("%3.0f", min_speed.getValue()));
+			} else {
+				me["Simple_C1"].setText(" ---");
+				me["Simple_C2"].setText(" ---");
+				me["Simple_C3"].setText(" ---");
+				me["Simple_C5"].setText(" ---");
+			}
+			
 			me["Simple_C1S"].setText("FLP RETR");
 			me["Simple_C2S"].setText("SLT RETR");
 			me["Simple_C3S"].setText("CLEAN  ");
@@ -1514,6 +1562,7 @@ var canvas_MCDU_base = {
 				
 				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);
+				me.fontSizeCenter(small, small, small, 0, 0, 0);
 				
 				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
 				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
@@ -1544,9 +1593,29 @@ var canvas_MCDU_base = {
 			me["Simple_L6S"].setText(" PREV");
 			me["Simple_R5"].setText(sprintf("%3.0f", engOutAcc.getValue()));
 			me["Simple_R5S"].setText("ENG OUT ACC");
-			me["Simple_C1"].setText(" ---");
-			me["Simple_C2"].setText(" ---");
-			me["Simple_C3"].setText(" ---");
+			
+			if (zfwSet.getValue() == 1 and blockSet.getValue() == 1) {
+				lbs1000 = KG2LB * num(zfw.getValue() + block.getValue());
+				
+				tgt_f = ((0.4352 * lbs1000) + 51.006) * 1.47;
+				setprop("FMGC/internal/f-speed", tgt_f);
+				tgt_s = ((0.0024 * lbs1000 * lbs1000) + (0.124 * lbs1000) + 88.942) * 1.23;
+				setprop("FMGC/internal/s-speed", tgt_s);
+				tgt_clean = 2 * lbs1000 * 0.45359237 + 85;
+				if (altitude.getValue() > 20000) {
+					tgt_clean += (altitude.getValue() - 20000) / 1000;
+				}
+				setprop("FMGC/internal/o-speed", tgt_clean);
+				
+				me["Simple_C1"].setText(sprintf("%3.0f", f_speed.getValue()));
+				me["Simple_C2"].setText(sprintf("%3.0f", s_speed.getValue()));
+				me["Simple_C3"].setText(sprintf("%3.0f", o_speed.getValue()));
+			} else {
+				me["Simple_C1"].setText(" ---");
+				me["Simple_C2"].setText(" ---");
+				me["Simple_C3"].setText(" ---");
+			}
+			
 			me["Simple_C1S"].setText("FLP RETR");
 			me["Simple_C2S"].setText("SLT RETR");
 			me["Simple_C3S"].setText("CLEAN  ");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -148,6 +148,13 @@ var canvas_MCDU_base = {
 		me["PERFAPPR_SE"].setColor(0.8078,0.8039,0.8078);
 		me["PERFAPPR_OE"].setColor(0.8078,0.8039,0.8078);
 		
+		me["PERFGA_FE"].setFont(symbol);
+		me["PERFGA_SE"].setFont(symbol);
+		me["PERFGA_OE"].setFont(symbol);
+		me["PERFGA_FE"].setColor(0.8078,0.8039,0.8078);
+		me["PERFGA_SE"].setColor(0.8078,0.8039,0.8078);
+		me["PERFGA_OE"].setColor(0.8078,0.8039,0.8078);
+		
 		me.page = canvas_group;
 		
 		return me;
@@ -157,7 +164,7 @@ var canvas_MCDU_base = {
 		"Simple_L1_Arrow","Simple_L2_Arrow","Simple_L3_Arrow","Simple_L4_Arrow","Simple_L5_Arrow","Simple_L6_Arrow","Simple_R1","Simple_R2","Simple_R3","Simple_R4","Simple_R5","Simple_R6","Simple_R1S","Simple_R2S","Simple_R3S","Simple_R4S","Simple_R5S",
 		"Simple_R6S","Simple_R1_Arrow","Simple_R2_Arrow","Simple_R3_Arrow","Simple_R4_Arrow","Simple_R5_Arrow","Simple_R6_Arrow","Simple_C1","Simple_C2","Simple_C3","Simple_C4","Simple_C5","Simple_C6","Simple_C1S","Simple_C2S","Simple_C3S","Simple_C4S",
 		"Simple_C5S","Simple_C6S","INITA","INITA_CoRoute","INITA_FltNbr","INITA_CostIndex","INITA_CruiseFLTemp","INITA_FromTo","INITA_InitRequest","INITA_AlignIRS","INITB","INITB_ZFWCG","INITB_ZFW","INITB_ZFW_S","INITB_Block","PERFTO","PERFTO_V1","PERFTO_VR",
-		"PERFTO_V2","PERFTO_FE","PERFTO_SE","PERFTO_OE","PERFAPPR","PERFAPPR_FE","PERFAPPR_SE","PERFAPPR_OE"];
+		"PERFTO_V2","PERFTO_FE","PERFTO_SE","PERFTO_OE","PERFAPPR","PERFAPPR_FE","PERFAPPR_SE","PERFAPPR_OE","PERFGA","PERFGA_FE","PERFGA_SE","PERFGA_OE"];
 	},
 	update: func() {
 		if (ac1.getValue() >= 110 and mcdu1_lgt.getValue() > 0.01) {
@@ -183,6 +190,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("MCDU MENU");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -266,6 +274,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText(sprintf("%s", "    " ~ acType.getValue()));
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -349,6 +358,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("DATA INDEX");
 				me["Simple_PageNum"].setText("1/2");
 				me["Simple_PageNum"].show();
@@ -430,6 +440,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("DATA INDEX");
 				me["Simple_PageNum"].setText("2/2");
 				me["Simple_PageNum"].show();
@@ -516,6 +527,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("POSITION MONITOR");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -614,6 +626,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("RADIO NAV");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -754,6 +767,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("INIT");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -910,6 +924,7 @@ var canvas_MCDU_base = {
 				me["INITB"].show();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("INIT");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1041,6 +1056,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("FUEL PRED");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1154,6 +1170,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].show();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("TAKE OFF");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1316,6 +1333,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].show();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText("APPR");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1432,6 +1450,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].show();
 				me["Simple_Title"].setText("GO AROUND");
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1539,6 +1558,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["Simple_Title"].setText(sprintf("%s", page));
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
@@ -1662,6 +1682,7 @@ var canvas_MCDU_base = {
 				me["INITB"].hide();
 				me["PERFTO"].hide();
 				me["PERFAPPR"].hide();
+				me["PERFGA"].hide();
 				me["ArrowLeft"].hide();
 				me["ArrowRight"].hide();
 				

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -1410,10 +1410,12 @@ var canvas_MCDU_base = {
 			me["Simple_R2"].setText(" [    ]");
 			me["Simple_R3"].setText(" [    ]");
 			me["Simple_R4"].setText(" [    ]");
+			me["Simple_R6"].setText("PHASE ");
 			me["Simple_R1S"].setText("FINAL");
 			me["Simple_R2S"].setText("MDA");
 			me["Simple_R3S"].setText("DH");
 			me["Simple_R4S"].setText("LDG CONF");
+			me["Simple_R6S"].setText("NEXT ");
 			me["Simple_C1"].setText(" ---");
 			me["Simple_C2"].setText(" ---");
 			me["Simple_C3"].setText(" ---");
@@ -1422,6 +1424,113 @@ var canvas_MCDU_base = {
 			me["Simple_C2S"].setText("SLT RETR");
 			me["Simple_C3S"].setText("CLEAN  ");
 			me["Simple_C5S"].setText("VLS   ");
+		} else if (page == "GA") {
+			if (!pageSwitch[i].getBoolValue()) {
+				me["Simple"].show();
+				me["Simple_Center"].show();
+				me["INITA"].hide();
+				me["INITB"].hide();
+				me["PERFTO"].hide();
+				me["PERFAPPR"].hide();
+				me["Simple_Title"].setText("GO AROUND");
+				me["Simple_PageNum"].setText("X/X");
+				me["Simple_PageNum"].hide();
+				me["ArrowLeft"].hide();
+				me["ArrowRight"].hide();
+				
+				me["Simple_L1"].hide();
+				me["Simple_L2"].hide();
+				me["Simple_L3"].hide();
+				me["Simple_L4"].hide();
+				me["Simple_L5"].show();
+				me["Simple_L6"].show();
+				me["Simple_L0S"].hide();
+				me["Simple_L1S"].hide();
+				me["Simple_L2S"].hide();
+				me["Simple_L3S"].hide();
+				me["Simple_L4S"].hide();
+				me["Simple_L5S"].show();
+				me["Simple_L6S"].show();
+				me["Simple_L1_Arrow"].hide();
+				me["Simple_L2_Arrow"].hide();
+				me["Simple_L3_Arrow"].hide();
+				me["Simple_L4_Arrow"].hide();
+				me["Simple_L5_Arrow"].hide();
+				me["Simple_L6_Arrow"].show();
+				me["Simple_R1"].hide();
+				me["Simple_R2"].hide();
+				me["Simple_R3"].hide();
+				me["Simple_R4"].hide();
+				me["Simple_R5"].show();
+				me["Simple_R6"].hide();
+				me["Simple_R1S"].hide();
+				me["Simple_R2S"].hide();
+				me["Simple_R3S"].hide();
+				me["Simple_R4S"].hide();
+				me["Simple_R5S"].show();
+				me["Simple_R6S"].hide();
+				me["Simple_R1_Arrow"].hide();
+				me["Simple_R2_Arrow"].hide();
+				me["Simple_R3_Arrow"].hide();
+				me["Simple_R4_Arrow"].hide();
+				me["Simple_R5_Arrow"].hide();
+				me["Simple_R6_Arrow"].hide();
+				me["Simple_C1"].show();
+				me["Simple_C2"].show();
+				me["Simple_C3"].show();
+				me["Simple_C4"].hide();
+				me["Simple_C5"].hide();
+				me["Simple_C6"].hide();
+				me["Simple_C1S"].show();
+				me["Simple_C2S"].show();
+				me["Simple_C3S"].show();
+				me["Simple_C4S"].hide();
+				me["Simple_C5S"].hide();
+				me["Simple_C6S"].hide();
+				
+				me.fontLeft(default, default, default, default, default, default);
+				me.fontLeftS(default, default, default, default, default, default);
+				me.fontRight(default, symbol, 0, 0, default, default);
+				me.fontRightS(default, default, default, default, default, default);
+				
+				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
+				me.fontSizeRight(normal, small, 0, 0, 0, normal);
+				
+				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
+				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
+				me.colorLeftArrow("wht", "wht", "wht", "wht", "wht", "wht");
+				me.colorRight("wht", "blu", "blu", "blu", "blu", "wht");
+				me.colorRightS("wht", "wht", "wht", "wht", "wht", "wht");
+				me.colorRightArrow("wht", "wht", "wht", "wht", "wht", "wht");
+				me.colorCenter("grn", "grn", "grn", "wht", "wht", "wht");
+				me.colorCenterS("wht", "wht", "wht", "wht", "wht", "wht");
+				
+				pageSwitch[i].setBoolValue(1);
+			}
+			
+			if (thrAccSet.getValue() == 1) {
+				me["Simple_L5"].setFontSize(normal);
+			} else {
+				me["Simple_L5"].setFontSize(small);
+			}
+			if (engOutAccSet.getValue() == 1) {
+				me["Simple_R5"].setFontSize(normal);
+			} else {
+				me["Simple_R5"].setFontSize(small);
+			}
+			
+			me["Simple_L5"].setText(sprintf("%s", clbReducFt.getValue() ~ "/" ~ reducFt.getValue()));
+			me["Simple_L6"].setText(" PHASE");
+			me["Simple_L5S"].setText("THR RED/ACC");
+			me["Simple_L6S"].setText(" PREV");
+			me["Simple_R5"].setText(sprintf("%3.0f", engOutAcc.getValue()));
+			me["Simple_R5S"].setText("ENG OUT ACC");
+			me["Simple_C1"].setText(" ---");
+			me["Simple_C2"].setText(" ---");
+			me["Simple_C3"].setText(" ---");
+			me["Simple_C1S"].setText("FLP RETR");
+			me["Simple_C2S"].setText("SLT RETR");
+			me["Simple_C3S"].setText("CLEAN  ");
 		} else if (page == "CLB" or page == "CRZ" or page == "DES") {
 			if (!pageSwitch[i].getBoolValue()) {
 				me["Simple"].show();

--- a/Models/Instruments/MCDU/res/mcdu.svg
+++ b/Models/Instruments/MCDU/res/mcdu.svg
@@ -1678,4 +1678,87 @@
          y="385.6102"
          style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:63.9924px;line-height:1.25;font-family:'Helvetica Medium';-inkscape-font-specification:'Helvetica Medium,  Medium';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1">=</tspan></text>
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="PERFGA"
+     inkscape:label="PERFGA">
+    <text
+       inkscape:label="#text4244"
+       transform="scale(0.991516,1.0085566)"
+       id="PERFGA_F"
+       y="187.10254"
+       x="399.48752"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:70px;line-height:1.25;font-family:BoeingCDULarge;-inkscape-font-specification:BoeingCDULarge;text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         y="187.10254"
+         x="399.48752"
+         id="tspan1079"
+         sodipodi:role="line">F</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="398.21817"
+       y="304.35275"
+       id="PERFGA_S"
+       transform="scale(0.991516,1.0085566)"
+       inkscape:label="#text4244"><tspan
+         sodipodi:role="line"
+         id="tspan1082"
+         x="398.21817"
+         y="304.35275"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:70px;line-height:1.25;font-family:BoeingCDULarge;-inkscape-font-specification:BoeingCDULarge;text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1">S</tspan></text>
+    <text
+       inkscape:label="#text4244"
+       transform="scale(0.991516,1.0085566)"
+       id="PERFGA_O"
+       y="422.15305"
+       x="398.21817"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:70px;line-height:1.25;font-family:BoeingCDULarge;-inkscape-font-specification:BoeingCDULarge;text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         y="422.15305"
+         x="398.21817"
+         id="tspan1085"
+         sodipodi:role="line">O</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="478.87796"
+       y="171.04486"
+       id="PERFGA_FE"
+       transform="scale(0.90642126,1.1032398)"
+       inkscape:label="#text4244"><tspan
+         sodipodi:role="line"
+         id="tspan1088"
+         x="478.87796"
+         y="171.04486"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:63.9924px;line-height:1.25;font-family:'Helvetica Medium';-inkscape-font-specification:'Helvetica Medium,  Medium';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1">=</tspan></text>
+    <text
+       inkscape:label="#text4244"
+       transform="scale(0.90642126,1.1032398)"
+       id="PERFGA_SE"
+       y="278.32764"
+       x="478.87796"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:63.9924px;line-height:1.25;font-family:'Helvetica Medium';-inkscape-font-specification:'Helvetica Medium,  Medium';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         y="278.32764"
+         x="478.87796"
+         id="tspan1091"
+         sodipodi:role="line">=</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="478.87796"
+       y="385.6102"
+       id="PERFGA_OE"
+       transform="scale(0.90642126,1.1032398)"
+       inkscape:label="#text4244"><tspan
+         sodipodi:role="line"
+         id="tspan1094"
+         x="478.87796"
+         y="385.6102"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:63.9924px;line-height:1.25;font-family:'Helvetica Medium';-inkscape-font-specification:'Helvetica Medium,  Medium';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1">=</tspan></text>
+  </g>
 </svg>

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -88,7 +88,6 @@ var fd_pitch = props.globals.getNode("it-autoflight/fd/pitch-bar", 1);
 var decision = props.globals.getNode("instrumentation/mk-viii/inputs/arinc429/decision-height", 1);
 var slip_skid = props.globals.getNode("instrumentation/pfd/slip-skid", 1);
 var FMGCphase = props.globals.getNode("FMGC/status/phase", 1);
-var tostate = props.globals.getNode("FMGC/status/to-state", 1);
 var loc = props.globals.getNode("instrumentation/nav[0]/heading-needle-deflection-norm", 1);
 var gs = props.globals.getNode("instrumentation/nav[0]/gs-needle-deflection-norm", 1);
 var show_hdg = props.globals.getNode("it-autoflight/custom/show-hdg", 1);
@@ -1202,11 +1201,11 @@ var canvas_PFD_1 = {
 			
 				me.SPDv1trgtdiff = tgt_v1 - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDv1trgtdiff >= -42 and me.SPDv1trgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDv1trgtdiff >= -42 and me.SPDv1trgtdiff <= 42) {
 					me["v1_group"].show();
 					me["v1_text"].hide();
 					me["v1_group"].setTranslation(0, me.V1trgt * -6.6);
-				} else if (tostate.getValue() == '1') {
+				} else if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2) {
 					me["v1_group"].hide();
 					me["v1_text"].show();
 					me["v1_text"].setText(sprintf("%3.0f", v1.getValue()));
@@ -1231,7 +1230,7 @@ var canvas_PFD_1 = {
 			
 				me.SPDvrtrgtdiff = tgt_vr - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDvrtrgtdiff >= -42 and me.SPDvrtrgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDvrtrgtdiff >= -42 and me.SPDvrtrgtdiff <= 42) {
 					me["vr_speed"].show();
 					me["vr_speed"].setTranslation(0, me.VRtrgt * -6.6);
 				} else {
@@ -1253,11 +1252,11 @@ var canvas_PFD_1 = {
 			
 				me.SPDv2trgtdiff = tgt_v2 - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDv2trgtdiff >= -42 and me.SPDv2trgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDv2trgtdiff >= -42 and me.SPDv2trgtdiff <= 42) {
 					me["ASI_target"].show();
 					me["ASI_target"].setTranslation(0, me.V2trgt * -6.6);
 					me["ASI_digit_UP"].setText(sprintf("%3.0f", v2.getValue()));
-				} else if (tostate.getValue() == '1') {
+				} else if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2) {
 					me["ASI_target"].hide();
 					me["ASI_digit_UP"].setText(sprintf("%3.0f", v2.getValue()));
 				}
@@ -1848,11 +1847,11 @@ var canvas_PFD_2 = {
 			
 				me.SPDv1trgtdiff = tgt_v1 - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDv1trgtdiff >= -42 and me.SPDv1trgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDv1trgtdiff >= -42 and me.SPDv1trgtdiff <= 42) {
 					me["v1_group"].show();
 					me["v1_text"].hide();
 					me["v1_group"].setTranslation(0, me.V1trgt * -6.6);
-				} else if (tostate.getValue() == '1') {
+				} else if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2) {
 					me["v1_group"].hide();
 					me["v1_text"].show();
 					me["v1_text"].setText(sprintf("%3.0f", v1.getValue()));
@@ -1877,7 +1876,7 @@ var canvas_PFD_2 = {
 			
 				me.SPDvrtrgtdiff = tgt_vr - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDvrtrgtdiff >= -42 and me.SPDvrtrgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDvrtrgtdiff >= -42 and me.SPDvrtrgtdiff <= 42) {
 					me["vr_speed"].show();
 					me["vr_speed"].setTranslation(0, me.VRtrgt * -6.6);
 				} else {
@@ -1899,11 +1898,11 @@ var canvas_PFD_2 = {
 			
 				me.SPDv2trgtdiff = tgt_v2 - ind_spd;
 			
-				if (tostate.getValue() == '1' and me.SPDv2trgtdiff >= -42 and me.SPDv2trgtdiff <= 42) {
+				if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2 and me.SPDv2trgtdiff >= -42 and me.SPDv2trgtdiff <= 42) {
 					me["ASI_target"].show();
 					me["ASI_target"].setTranslation(0, me.V2trgt * -6.6);
 					me["ASI_digit_UP"].setText(sprintf("%3.0f", v2.getValue()));
-				} else if (tostate.getValue() == '1') {
+				} else if (pts.Position.gearAglFt.getValue() < 55 and FMGCphase.getValue() <= 2) {
 					me["ASI_target"].hide();
 					me["ASI_digit_UP"].setText(sprintf("%3.0f", v2.getValue()));
 				}

--- a/Nasal/FMGC/FMGC-b.nas
+++ b/Nasal/FMGC/FMGC-b.nas
@@ -155,7 +155,7 @@ var Text = {
 };
 
 var Setting = {
-	reducAglFt: props.globals.initNode("/it-autoflight/settings/reduc-agl-ft", 3000, "INT"), # Changable from MCDU
+	reducAglFt: props.globals.initNode("/it-autoflight/settings/reduc-agl-ft", 1500, "INT"), # Changable from MCDU #eventually set to 1500 above runway
 };
 
 var Sound = {

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -102,7 +102,7 @@ setprop("FMGC/internal/mng-spd", 157);
 setprop("FMGC/internal/mng-spd-cmd", 157);
 setprop("FMGC/internal/mng-kts-mach", 0);
 setprop("FMGC/internal/mach-switchover", 0);
-setprop("it-autoflight/settings/reduc-agl-ft", 3000);
+setprop("it-autoflight/settings/reduc-agl-ft", 1500); #eventually set to 1500 above runway
 setprop("it-autoflight/internal/vert-speed-fpm", 0);
 setprop("it-autoflight/output/fma-pwr", 0);
 setprop("instrumentation/nav[0]/nav-id", "XXX");
@@ -123,7 +123,7 @@ var FMGCinit = func {
 	setprop("FMGC/internal/mng-spd-cmd", 157);
 	setprop("FMGC/internal/mng-kts-mach", 0);
 	setprop("FMGC/internal/mach-switchover", 0);
-	setprop("it-autoflight/settings/reduc-agl-ft", 3000);
+	setprop("it-autoflight/settings/reduc-agl-ft", 1500); #eventually set to 1500 above runway
 	setprop("FMGC/internal/decel", 0);
 	setprop("FMGC/internal/loc-source", "NAV0");
 	setprop("FMGC/internal/optalt", 0);

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -179,6 +179,8 @@ var lskbutton = func(btn, i) {
 			perfDESInput("L5",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "APPR") {
 			perfAPPRInput("L5",i);
+		} else if (getprop("MCDU[" ~ i ~ "]/page") == "GA") {
+			perfGAInput("L5",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "RADNAV") {
 			radnavInput("L5",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "PRINTFUNC") {
@@ -199,6 +201,8 @@ var lskbutton = func(btn, i) {
 			perfDESInput("L6",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "APPR") {
 			perfAPPRInput("L6",i);
+		} else if (getprop("MCDU[" ~ i ~ "]/page") == "GA") {
+			perfGAInput("L6",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "PRINTFUNC2") {
 			printInput2("L6",i);
 		} else {
@@ -269,6 +273,8 @@ var rskbutton = func(btn, i) {
 	} else if (btn == "5") {
 		if (getprop("MCDU[" ~ i ~ "]/page") == "TO") {
 			perfTOInput("R5",i);
+		} else if (getprop("MCDU[" ~ i ~ "]/page") == "GA") {
+			perfGAInput("R5",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "RADNAV") {
 			radnavInput("R5",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "DATA") {
@@ -293,6 +299,8 @@ var rskbutton = func(btn, i) {
 			perfCRZInput("R6",i);
 		} else if (getprop("MCDU[" ~ i ~ "]/page") == "DES") {
 			perfDESInput("R6",i);
+		} else if (getprop("MCDU[" ~ i ~ "]/page") == "APPR") {
+			perfAPPRInput("R6",i);
 		} else if ((getprop("MCDU[" ~ i ~ "]/page") == "DATA") or (getprop("MCDU[" ~ i ~ "]/page") == "PRINTFUNC") or (getprop("MCDU[" ~ i ~ "]/page") == "PRINTFUNC2")) {
 			if (getprop("MCDU[" ~ i ~ "]/scratchpad") != "AOC DISABLED") {
 				if (getprop("MCDU[" ~ i ~ "]/scratchpad-msg") == 1) {
@@ -374,6 +382,8 @@ var pagebutton = func(btn, i) {
 				setprop("MCDU[" ~ i ~ "]/page", "DES");
 			} else if (getprop("FMGC/status/phase") == 5) {
 				setprop("MCDU[" ~ i ~ "]/page", "APPR");
+			} else if (getprop("FMGC/status/phase") == 6) {
+				setprop("MCDU[" ~ i ~ "]/page", "GA");
 			}
 		} else if (btn == "init") {
 			setprop("MCDU[" ~ i ~ "]/page", "INITA");

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -31,6 +31,13 @@ var MCDU_reset = func(i) {
 	setprop("FMGC/internal/v1", 0);
 	setprop("FMGC/internal/vr", 0);
 	setprop("FMGC/internal/v2", 0);
+	setprop("FMGC/internal/f-speed", 0);
+	setprop("FMGC/internal/s-speed", 0);
+	setprop("FMGC/internal/o-speed", 0);
+	setprop("FMGC/internal/minspeed", 0);
+	#setprop("FMGC/internal/vapp-speed", 0);
+	setprop("FMGC/internal/vr", 0);
+	setprop("FMGC/internal/v2", 0);
 	setprop("FMGC/internal/block", 0.0);
 	setprop("FMGC/internal/zfw", 0);
 	setprop("FMGC/internal/zfwcg", 55.1); # 25KG default

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -26,8 +26,8 @@ var MCDU_reset = func(i) {
 	setprop("FMGC/internal/cruise-fl", 100);
 	setprop("FMGC/internal/cost-index", "0");
 	setprop("FMGC/internal/trans-alt", 18000);
-	setprop("FMGC/internal/reduc-agl-ft", "3000");
-	setprop("FMGC/internal/eng-out-reduc", "3500");
+	setprop("FMGC/internal/reduc-agl-ft", "1500"); #eventually set to 1500 above runway
+	setprop("FMGC/internal/eng-out-reduc", "1500");
 	setprop("FMGC/internal/v1", 0);
 	setprop("FMGC/internal/vr", 0);
 	setprop("FMGC/internal/v2", 0);

--- a/Nasal/MCDU/PERFAPPR.nas
+++ b/Nasal/MCDU/PERFAPPR.nas
@@ -3,5 +3,7 @@
 var perfAPPRInput = func(key, i) {
 	if (key == "L6") {
 		setprop("MCDU[" ~ i ~ "]/page", "DES");
+	} else if (key == "R6") {
+		setprop("MCDU[" ~ i ~ "]/page", "GA");
 	}
 }

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -3,6 +3,7 @@
 # uses universal values, will implement separately once FPLN is finished
 
 var perfGAInput = func(key, i) {
+	var scratchpad = getprop("MCDU[" ~ i ~ "]/scratchpad");
 	if (key == "L5") {
 		if (scratchpad == "CLR") {
 			setprop("systems/thrust/clbreduc-ft", "1500");

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 Matthew Maring (hayden2000)
+
+var perfGAInput = func(key, i) {
+	if (key == "L6") {
+		setprop("MCDU[" ~ i ~ "]/page", "APPR");
+	}
+}

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -1,7 +1,50 @@
 # Copyright (c) 2020 Matthew Maring (hayden2000)
 
+# uses universal values, will implement separately once FPLN is finished
+
 var perfGAInput = func(key, i) {
-	if (key == "L6") {
+	if (key == "L5") {
+		if (scratchpad == "CLR") {
+			setprop("systems/thrust/clbreduc-ft", "1500");
+			setprop("FMGC/internal/reduc-agl-ft", "1500");
+			setprop("MCDUC/thracc-set", 0);
+			setprop("MCDU[" ~ i ~ "]/scratchpad-msg", 0);
+			setprop("MCDU[" ~ i ~ "]/scratchpad", "");
+		} else {
+			var tfs = size(scratchpad);
+			if (tfs >= 7 and tfs <= 9 and find("/", scratchpad) != -1) {
+				var thracc = split("/", scratchpad);
+				var thrred = size(thracc[0]);
+				var acc = size(thracc[1]);
+				if ((thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)) {
+					setprop("systems/thrust/clbreduc-ft", thracc[0]);
+					setprop("FMGC/internal/reduc-agl-ft", thracc[1]);
+					setprop("MCDUC/thracc-set", 1);
+					setprop("MCDU[" ~ i ~ "]/scratchpad", "");
+				} else {
+					notAllowed(i);
+				}
+			} else {
+				notAllowed(i);
+			}
+		}
+	} else if (key == "L6") {
 		setprop("MCDU[" ~ i ~ "]/page", "APPR");
+	} else if (key == "R5") {
+		if (scratchpad == "CLR") {
+			setprop("FMGC/internal/eng-out-reduc", "1500");
+			setprop("MCDUC/reducacc-set", 0);
+			setprop("MCDU[" ~ i ~ "]/scratchpad-msg", 0);
+			setprop("MCDU[" ~ i ~ "]/scratchpad", "");
+		} else {
+			var tfs = size(scratchpad);
+			if (tfs >= 3 and tfs <= 5) {
+				setprop("FMGC/internal/eng-out-reduc", scratchpad);
+				setprop("MCDUC/reducacc-set", 1);
+				setprop("MCDU[" ~ i ~ "]/scratchpad", "");
+			} else {
+				notAllowed(i);
+			}
+		}
 	}
 }

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -85,7 +85,7 @@ var perfTOInput = func(key, i) {
 	} else if (key == "L5") {
 		if (scratchpad == "CLR") {
 			setprop("systems/thrust/clbreduc-ft", "1500");
-			setprop("FMGC/internal/reduc-agl-ft", "3000");
+			setprop("FMGC/internal/reduc-agl-ft", "1500");
 			setprop("MCDUC/thracc-set", 0);
 			setprop("MCDU[" ~ i ~ "]/scratchpad-msg", 0);
 			setprop("MCDU[" ~ i ~ "]/scratchpad", "");
@@ -162,7 +162,7 @@ var perfTOInput = func(key, i) {
 		}
 	} else if (key == "R5") {
 		if (scratchpad == "CLR") {
-			setprop("FMGC/internal/eng-out-reduc", "3500");
+			setprop("FMGC/internal/eng-out-reduc", "1500");
 			setprop("MCDUC/reducacc-set", 0);
 			setprop("MCDU[" ~ i ~ "]/scratchpad-msg", 0);
 			setprop("MCDU[" ~ i ~ "]/scratchpad", "");

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -57,7 +57,7 @@ var perfTOInput = func(key, i) {
 				if (scratchpad >= 100 and scratchpad <= 200) {
 					setprop("FMGC/internal/v2", scratchpad);
 					setprop("FMGC/internal/v2-set", 1);
-					setprop("it-autoflight/settings/togaspd", scratchpad + 10);
+					setprop("it-autoflight/settings/togaspd", scratchpad + 10); #work-in-progress
 					setprop("MCDU[" ~ i ~ "]/scratchpad", "");
 				} else {
 					notAllowed(i);

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -57,7 +57,7 @@ var perfTOInput = func(key, i) {
 				if (scratchpad >= 100 and scratchpad <= 200) {
 					setprop("FMGC/internal/v2", scratchpad);
 					setprop("FMGC/internal/v2-set", 1);
-					setprop("it-autoflight/settings/togaspd", scratchpad + 10); #work-in-progress
+					setprop("it-autoflight/settings/togaspd", scratchpad);
 					setprop("MCDU[" ~ i ~ "]/scratchpad", "");
 				} else {
 					notAllowed(i);


### PR DESCRIPTION
Keep V1/VR/V2 displayed from PREF setup until takeoff phase is over.
Fixes the error mentioned in #96, but may still be preexisting bugs.

If anyone knows/has info on what the managed speed should be doing after takeoff but before THR ACC is reached (set on PREF page with THR RED), that would be super helpful. Based on videos I could find, line 60 in /A320-family/Nasal/MCDU/PERFTO.nas seems incorrect, as none add 10 to V2:
setprop("it-autoflight/settings/togaspd", scratchpad + 10);

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
