### PR TITLE
Approaches start from LSK3, not LSK2.

### DIFF
--- a/Nasal/MCDU/ARRIVAL.nas
+++ b/Nasal/MCDU/ARRIVAL.nas
@@ -459,7 +459,7 @@ var arrivalPage = {
 	},
 	arrPushbuttonLeft: func(index) {
 		if (me.activePage == 0) {
-			if (size(me.approaches) >= (index - 1) and index != 2) {
+			if (size(me.approaches) >= (index - 2) and index != 2) {
 				if (!dirToFlag) {
 					me.selectedApproach = me.arrAirport[0].getIAP(me.approaches[index - 3 + me.scrollApproach]);
 					me.makeTmpy();


### PR DESCRIPTION
Test the correct LSK index against the number of approaches available.

### Description of Changes
After selecting the desintation airfield in the flight plan, attempting to select the first approach fails because the if statement protecting the selection code subtracts 2 from the LSK index, but unlike the STAR selection (which genuinely starts at LSK2), approaches are listed from LSK3.

### Screenshots (optional)
None

### Bugs fixed (if any)
No additional issue.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
