### PR TITLE
Approaches can be slewed if there are exactly four

### DIFF
--- a/Nasal/MCDU/ARRIVAL.nas
+++ b/Nasal/MCDU/ARRIVAL.nas
@@ -513,7 +513,7 @@ var arrivalPage = {
 		if (me.activePage == 0) {
 			if (me.enableScrollApproach) {
 				me.scrollApproach += 1;
-				if (me.scrollApproach > size(me.approaches) - 4) {
+				if (me.scrollApproach > size(me.approaches) - 3) {
 					me.scrollApproach = 0;
 				}
 				me.updateApproaches();
@@ -539,7 +539,7 @@ var arrivalPage = {
 			if (me.enableScrollApproach) {
 				me.scrollApproach -= 1;
 				if (me.scrollApproach < 0) {
-					me.scrollApproach = size(me.approaches) - 4;
+					me.scrollApproach = size(me.approaches) - 3;
 				}
 				me.updateApproaches();
 			}


### PR DESCRIPTION
### Description of Changes
STARS slewed correctly, and approaches would if there were more than 4, but with exactly 4, there was an off by one error which didn't activate the slew functionality. This is easily tested in the default navigation data using any airport with no approach data and four runways, such as EGPH (Edinburgh).

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
