### PR TITLE
Fix bogus CLB/DES and R6 arrow in VERTREV pages

### DIFF
--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -606,7 +606,7 @@ var rskbutton = func(btn, i) {
 		} else if (getprop("/MCDU[" ~ i ~ "]/page") == "F-PLNA" or getprop("/MCDU[" ~ i ~ "]/page") == "F-PLNB") {
 			canvas_mcdu.myFpln[i].pushButtonRight(6);
 		} else if (getprop("/MCDU[" ~ i ~ "]/page") == "VERTREV") {
-			setprop("/MCDU/[" ~ i ~ "]/page", "F-PLNA");
+			setprop("/MCDU[" ~ i ~ "]/page", "F-PLNA");
 		} else if (getprop("/MCDU[" ~ i ~ "]/page") == "DIRTO") {
 			canvas_mcdu.myDirTo[i].fieldR6();
 		} else {

--- a/Nasal/MCDU/VERTREV.nas
+++ b/Nasal/MCDU/VERTREV.nas
@@ -71,7 +71,7 @@ var vertRev = {
 			# When CLB/DES are shown, a small "OR" should be shown between them.
 			# The 'arrows' for CLB/DES should actually be asterisks.
 			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
-			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
+			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "amb"], ["ack", "wht", "ack", "ack", "wht", "amb"]];
 			me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 1, 0, 0, 0]];
 		} else {
 			me.title = ["VERT REV", " AT ", me.id];

--- a/Nasal/MCDU/VERTREV.nas
+++ b/Nasal/MCDU/VERTREV.nas
@@ -50,7 +50,7 @@ var vertRev = {
 			me.L5 = [" WIND DATA", nil, "wht"];
 			me.L6 = [" RETURN", nil, "wht"];
 			me.R2 = ["RTA ", nil, "wht"];
-			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
+			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 0]];
 			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 			me.fontMatrix = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]];
 		} if (me.type == 2) { 
@@ -61,11 +61,10 @@ var vertRev = {
 			me.L3 = [" [    ]", " SPD CSTR", "blu"];
 			me.L4 = [" CONSTANT MACH", nil, "wht"];
 			me.L5 = [" WIND DATA", nil, "wht"];
-			me.L6 = [" CLB", nil, "wht"];
+			me.L6 = [" RETURN", nil, "wht"];
 			me.R2 = ["RTA ", nil, "wht"];
 			me.R3 = ["[      ] ", "ALT CSTR  ", "blu"];
-			me.R6 = ["DES ", nil, "wht"];
-			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
+			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 0]];
 			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 			me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 1, 0, 0, 0]];
 		} else {
@@ -84,8 +83,7 @@ var vertRev = {
 				me.L5 = [" WIND DATA", nil, "wht"];
 				me.L6 = [" RETURN", nil, "wht"];
 				me.R2 = ["RTA ", nil, "wht"];
-				me.R6 = ["DES ", nil, "wht"];
-				me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
+				me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 0]];
 				me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 				me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 0]];
 			} elsif (me.type == 1) {
@@ -102,8 +100,7 @@ var vertRev = {
 				me.L6 = [" RETURN", nil, "wht"];
 				me.R2 = ["RTA ", nil, "wht"];
 				me.R3 = ["3000", "G/S INTCP", "grn"];
-				me.R6 = ["DES ", nil, "wht"];
-				me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
+				me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 0]];
 				me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 				me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 0, 0]];
 			}

--- a/Nasal/MCDU/VERTREV.nas
+++ b/Nasal/MCDU/VERTREV.nas
@@ -65,6 +65,11 @@ var vertRev = {
 			me.R2 = ["RTA ", nil, "wht"];
 			me.R3 = ["[      ] ", "ALT CSTR  ", "blu"];
 			me.R6 = ["DES ", nil, "amb"];
+			# When the system does vertical planning, L6 should be RETURN and R6 not used if the MCDU knows the waypoint is during climb or descent.
+			# The CLB or DES prompts should only be shown for a vertical revision in the cruise phase.
+			# For now we fake it and allow the user to press either, which both act like RETURN.
+			# When CLB/DES are shown, a small "OR" should be shown between them.
+			# The 'arrows' for CLB/DES should actually be asterisks.
 			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
 			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 			me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 1, 0, 0, 0]];

--- a/Nasal/MCDU/VERTREV.nas
+++ b/Nasal/MCDU/VERTREV.nas
@@ -61,10 +61,11 @@ var vertRev = {
 			me.L3 = [" [    ]", " SPD CSTR", "blu"];
 			me.L4 = [" CONSTANT MACH", nil, "wht"];
 			me.L5 = [" WIND DATA", nil, "wht"];
-			me.L6 = [" RETURN", nil, "wht"];
+			me.L6 = [" CLB", nil, "amb"];
 			me.R2 = ["RTA ", nil, "wht"];
 			me.R3 = ["[      ] ", "ALT CSTR  ", "blu"];
-			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 0]];
+			me.R6 = ["DES ", nil, "amb"];
+			me.arrowsMatrix = [[0, 0, 0, 1, 1, 1], [0, 1, 0, 0, 0, 1]];
 			me.arrowsColour = [["ack", "ack", "ack", "wht", "wht", "wht"], ["ack", "wht", "ack", "ack", "wht", "wht"]];
 			me.fontMatrix = [[0, 0, 1, 0, 0, 0], [0, 0, 1, 0, 0, 0]];
 		} else {


### PR DESCRIPTION
### Description of Changes
The VERTREV page correctly had "RETURN" as L6 with an arrow for PPOS/origin/destination, but in waypoint variant had "CLB" as L6 and "DES" as R6, and all four had the right hand arrow enabled.

All four now have the arrow at R6 removed and the L6 label set to "RETURN", which I believe is correct behaviour for all of them.

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
