### PR TITLE
Added functionality to FO's ACP

### DIFF
--- a/Nasal/Panels/acp.nas
+++ b/Nasal/Panels/acp.nas
@@ -7,32 +7,56 @@
 
 # NOTE: This is just temporary until FG allows a full implementation of the audio system.
 
-var vhf1_recive = props.globals.initNode("/controls/audio/acp[0]/vhf1-recive", 1, "BOOL");
-var vhf2_recive = props.globals.initNode("/controls/audio/acp[0]/vhf2-recive", 1, "BOOL");
+var vhf1_capt_recive = props.globals.initNode("/controls/audio/acp[0]/vhf1-recive", 1, "BOOL");
+var vhf2_capt_recive = props.globals.initNode("/controls/audio/acp[0]/vhf2-recive", 1, "BOOL");
+var vhf1_capt_volume = props.globals.initNode("/controls/audio/acp[0]/vhf1-volume", 1, "DOUBLE");
+var vhf2_capt_volume = props.globals.initNode("/controls/audio/acp[0]/vhf2-volume", 1, "DOUBLE");
 
-var vhf1_volume = props.globals.initNode("/controls/audio/acp[0]/vhf1-volume", 1, "DOUBLE");
-var vhf2_volume = props.globals.initNode("/controls/audio/acp[0]/vhf2-volume", 1, "DOUBLE");
+var vhf1_fo_recive = props.globals.initNode("/controls/audio/acp[1]/vhf1-recive", 1, "BOOL");
+var vhf2_fo_recive = props.globals.initNode("/controls/audio/acp[1]/vhf2-recive", 1, "BOOL");
+var vhf1_fo_volume = props.globals.initNode("/controls/audio/acp[1]/vhf1-volume", 1, "DOUBLE");
+var vhf2_fo_volume = props.globals.initNode("/controls/audio/acp[1]/vhf2-volume", 1, "DOUBLE");
 
 var com1_volume = props.globals.getNode("instrumentation/comm[0]/volume");
 var com2_volume = props.globals.getNode("instrumentation/comm[1]/volume");
 
 var init = func() {
-	vhf1_recive.setValue(1);
-	vhf2_recive.setValue(1);
-	vhf1_volume.setValue(1);
-	vhf2_volume.setValue(0.8);
+	vhf1_capt_recive.setValue(1);
+	vhf2_capt_recive.setValue(1);
+	vhf1_capt_volume.setValue(1);
+	vhf2_capt_volume.setValue(0.8);
+	vhf1_fo_recive.setValue(1);
+	vhf2_fo_recive.setValue(1);
+	vhf1_fo_volume.setValue(0.8);
+	vhf2_fo_volume.setValue(1);
 }
 
-var update_instruments = func(com_no) {
-	if (com_no == 0) {
-		if (vhf1_recive.getValue()) {
-			com1_volume.setValue(vhf1_volume.getValue());
+var update_com1 = func() {	
+	if (getprop("systems/acconfig/options/fo-view") == 1) {
+		if (vhf1_fo_recive.getValue()) {
+			com1_volume.setValue(vhf1_fo_volume.getValue());
 		} else {
 			com1_volume.setValue(0);
 		}
-	} else if (com_no == 1) {
-		if (vhf2_recive.getValue()) {
-			com2_volume.setValue(vhf2_volume.getValue());
+	} else {
+		if (vhf1_capt_recive.getValue()) {
+			com1_volume.setValue(vhf1_capt_volume.getValue());
+		} else {
+			com1_volume.setValue(0);
+		}
+	}
+}
+
+var update_com2 = func() {	
+	if (getprop("systems/acconfig/options/fo-view") == 1) {
+		if (vhf2_fo_recive.getValue()) {
+			com2_volume.setValue(vhf2_fo_volume.getValue());
+		} else {
+			com2_volume.setValue(0);
+		}
+	} else {
+		if (vhf2_capt_recive.getValue()) {
+			com2_volume.setValue(vhf2_capt_volume.getValue());
 		} else {
 			com2_volume.setValue(0);
 		}
@@ -40,17 +64,39 @@ var update_instruments = func(com_no) {
 }
 
 setlistener("/controls/audio/acp[0]/vhf1-recive", func {
-        update_instruments(0);
+	update_com1();
 });
 
 setlistener("/controls/audio/acp[0]/vhf1-volume", func {
-        update_instruments(0);
+	update_com1();
 });
 
 setlistener("/controls/audio/acp[0]/vhf2-recive", func {
-        update_instruments(1);
+	update_com2();
 });
 
 setlistener("/controls/audio/acp[0]/vhf2-volume", func {
-        update_instruments(1);
+	update_com2();
 });
+
+setlistener("/controls/audio/acp[1]/vhf1-recive", func {
+	update_com1();
+});
+
+setlistener("/controls/audio/acp[1]/vhf1-volume", func {
+	update_com1();
+});
+
+setlistener("/controls/audio/acp[1]/vhf2-recive", func {
+	update_com2();
+});
+
+setlistener("/controls/audio/acp[1]/vhf2-volume", func {
+	update_com2();
+});
+
+setlistener("/systems/acconfig/options/fo-view", func {
+	update_com1();
+	update_com2();
+});
+


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
The audio for Com1 and Com2 can be controlled with the Captain's or the First Officer's ACP. It depends which one is set to Pilot Flying in the Aircraft Config dialog.

I changed the method a bit to avoid intricated if-clauses.

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
