### PR TITLE
Enable FPV functionality

### DIFF
--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -1026,24 +1026,6 @@ var canvas_PFD_base = {
 		me.AI_horizon_hdg_rot.setRotation(-roll_cur * D2R, me["AI_center"].getCenter());
 		me["AI_heading"].update();
 	},
-	
-	# Dim the yellow outline of fixed aircraft symbol on PFDs (when crew select TRK-FPA)
-	# 1 == dim 
-	# 0 == undim
-	dimFixedAircraftOutline: func(dim_bool) {
-		var r = 0.345098039;
-		var g = 0.349019608;
-		var b = 0.058823529;
-		
-		if (dim_bool == 0) {
-			r = 0.788235294;
-			g = 0.819607843;
-			b = 0.129411765;
-		} 
-
-		me["fixed_aircraft_outline_1"].setColor(r, g, b);
-		me["fixed_aircraft_outline_2"].setColor(r, g, b);
-	},
 
 	# Get Angle of Attack from ADR1 or, depending on Switching panel, ADR3
 	getAOAForPFD1: func() {
@@ -1138,12 +1120,10 @@ var canvas_PFD_1 = {
 		# If TRK FPA selected, display FPV on PFD1
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
-			me.dimFixedAircraftOutline(0);
 		} else {
 			var aoa = me.getAOAForPFD1();	
 			if (aoa == nil or (systems.ADIRS.ADIRunits[0].aligned != 1 and att_switch.getValue() == 0) or (systems.ADIRS.ADIRunits[2].aligned != 1 and att_switch.getValue() == -1)){
 				me["FPV"].hide();	
-				me.dimFixedAircraftOutline(0);
 			} else {
 				var roll_deg = roll.getValue() or 0; 
 				AICenter = me["AI_center"].getCenter();
@@ -1153,7 +1133,6 @@ var canvas_PFD_1 = {
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);
 				me["FPV"].setRotation(roll_deg * D2R); # It shouldn't be rotated, only the axis should be
 				me["FPV"].show();
-				me.dimFixedAircraftOutline(1);
 			}
 
 		}
@@ -1899,12 +1878,10 @@ var canvas_PFD_2 = {
 		# If TRK FPA selected, display FPV on PFD2
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
-			me.dimFixedAircraftOutline(0);
 		} else {
 			var aoa = me.getAOAForPFD2();
 			if (aoa == nil or (systems.ADIRS.ADIRunits[1].aligned != 1 and att_switch.getValue() == 0) or (systems.ADIRS.ADIRunits[2].aligned != 1 and att_switch.getValue() == 1)) {
 				me["FPV"].hide();	
-				me.dimFixedAircraftOutline(0);
 			} else {
 				var roll_deg = roll.getValue() or 0;	
 				AICenter = me["AI_center"].getCenter();
@@ -1914,7 +1891,6 @@ var canvas_PFD_2 = {
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);
 				me["FPV"].setRotation(roll_deg * D2R); # It shouldn't be rotated, only the axis should be
 				me["FPV"].show();
-				me.dimFixedAircraftOutline(1);
 			}
 		}
 

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -216,7 +216,7 @@ var canvas_PFD_base = {
 		"AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","ALT_box_flash","ALT_box","ALT_box_amber","ALT_scale","ALT_target","ALT_target_digit","ALT_one","ALT_two","ALT_three","ALT_four","ALT_five","ALT_digits","ALT_tens","ALT_digit_UP",
 		"ALT_digit_DN","ALT_error","ALT_group","ALT_group2","ALT_frame","VS_pointer","VS_box","VS_digit","VS_error","VS_group","QNH","QNH_setting","QNH_std","QNH_box","LOC_pointer","LOC_scale","GS_scale","GS_pointer","CRS_pointer","HDG_target","HDG_scale",
 		"HDG_one","HDG_two","HDG_three","HDG_four","HDG_five","HDG_six","HDG_seven","HDG_digit_L","HDG_digit_R","HDG_error","HDG_group","HDG_frame","TRK_pointer","machError","ilsError","ils_code","ils_freq","dme_dist","dme_dist_legend","ILS_HDG_R","ILS_HDG_L",
-		"ILS_right","ILS_left","outerMarker","middleMarker","innerMarker","v1_group","v1_text","vr_speed","F_target","S_target","FS_targets","flap_max","clean_speed","ground","ground_ref","FPV"];
+		"ILS_right","ILS_left","outerMarker","middleMarker","innerMarker","v1_group","v1_text","vr_speed","F_target","S_target","FS_targets","flap_max","clean_speed","ground","ground_ref","FPV", "fixed_aircraft_outline_1","fixed_aircraft_outline_2"];
 	},
 	updateDu1: func() {
 		var elapsedtime_act = elapsedtime.getValue();
@@ -1014,6 +1014,22 @@ var canvas_PFD_base = {
 		me.AI_horizon_hdg_rot.setRotation(-roll_cur * D2R, me["AI_center"].getCenter());
 		me["AI_heading"].update();
 	},
+	
+	dimFixedAircraftOutline: func() {
+		var r = 0.345098039;
+		var g = 0.349019608;
+		var b = 0.058823529;
+		me["fixed_aircraft_outline_1"].setColor(r, g, b);
+		me["fixed_aircraft_outline_2"].setColor(r, g, b);
+	},
+
+	undimFixedAircraftOutline: func() {
+			var r = 0.788235294;
+			var g = 0.819607843;
+			var b = 0.129411765;
+			me["fixed_aircraft_outline_1"].setColor(r, g, b);
+			me["fixed_aircraft_outline_2"].setColor(r, g, b);
+	},
 };
 
 var canvas_PFD_1 = {
@@ -1089,9 +1105,11 @@ var canvas_PFD_1 = {
 		# TODO - Hide FPV if error on PFD1
 		if (ap_trk_sw.getValue() == 0) {
 			me["FPV"].hide();	
+			me.undimFixedAircraftOutline();
 		} else {
-			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, math.clamp(aoa_1.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT);
+			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, (math.clamp(aoa_1.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT)/math.cos(math.abs(roll_cur)*D2R));
 			me["FPV"].show();
+			me.dimFixedAircraftOutline();
 		}
 
 		# ILS
@@ -1837,10 +1855,12 @@ var canvas_PFD_2 = {
 		# TODO - Deal with situation if AOA not available from ADR2
 		# TODO - Hide FPV if error on PFD2
 		if (ap_trk_sw.getValue() == 0) {
-			me["FPV"].hide();	
+			me["FPV"].hide();
+			me.undimFixedAircraftOutline();
 		} else {
-			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, math.clamp(aoa_2.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT);
+			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, (math.clamp(aoa_2.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT)/math.cos(math.abs(roll_cur)*D2R));
 			me["FPV"].show();
+			me.dimFixedAircraftOutline();
 		}
 
 		# ILS

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -1138,7 +1138,6 @@ var canvas_PFD_1 = {
 		
 		# FPV
 		# If TRK FPA selected on the FCU, display FPV on PFD1
-		# Display FPV in red and freeze if FPA outside the range of -9.9 degrees or 9.9 degrees
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
 			me.dimFixedAircraftOutline(0);
@@ -1155,15 +1154,16 @@ var canvas_PFD_1 = {
 				AICenter = me["AI_center"].getCenter();
 				var track_x_translation = me.getTrackDiffPixels(track_diff); 
 
-				if (fpa_deg > 9.9) {
-					alpha_deg = alpha_deg + (fpa_deg - 9.9);
-					me["FPV"].setColor(1, 0, 0);
-				} else if (fpa_deg < -9.9) {
-					alpha_deg = alpha_deg + (fpa_deg + 9.9);
-					me["FPV"].setColor(1, 0, 0);
-				} else {
-					me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
-				}
+				# Display FPV in red if FPA greater or less plus or minus 9.9 degrees
+				# if (fpa_deg > 9.9) {
+				# 	alpha_deg = alpha_deg + (fpa_deg - 9.9);
+				# 	me["FPV"].setColor(1, 0, 0);
+				# } else if (fpa_deg < -9.9) {
+				# 	alpha_deg = alpha_deg + (fpa_deg + 9.9);
+				# 	me["FPV"].setColor(1, 0, 0);
+				# } else {
+				# 	me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
+				# }
 
 				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(alpha_deg, -20, 20) * 12.5); 
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);
@@ -1914,7 +1914,6 @@ var canvas_PFD_2 = {
 		
 		# FPV
 		# If TRK FPA selected on the FCU, display FPV on PFD2
-		# Display FPV in red and freeze if FPA outside the range of -9.9 degrees or 9.9 degrees
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
 			me.dimFixedAircraftOutline(0);
@@ -1931,15 +1930,16 @@ var canvas_PFD_2 = {
 				AICenter = me["AI_center"].getCenter();
 				var track_x_translation = me.getTrackDiffPixels(track_diff);
 
-				if (fpa_deg > 9.9) {
-					alpha_deg = alpha_deg + (fpa_deg - 9.9);
-					me["FPV"].setColor(1, 0, 0);
-				} else if (fpa_deg < -9.9) {
-					alpha_deg = alpha_deg + (fpa_deg + 9.9);
-					me["FPV"].setColor(1, 0, 0);
-				} else {
-					me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
-				}
+				# Display FPV in red if FPA greater or less plus or minus 9.9 degrees
+				# if (fpa_deg > 9.9) {
+				# 	alpha_deg = alpha_deg + (fpa_deg - 9.9);
+				# 	me["FPV"].setColor(1, 0, 0);
+				# } else if (fpa_deg < -9.9) {
+				# 	alpha_deg = alpha_deg + (fpa_deg + 9.9);
+				# 	me["FPV"].setColor(1, 0, 0);
+				# } else {
+				# 	me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
+				# }
 
 				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(alpha_deg, -20, 20) * 12.5);
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -16,7 +16,7 @@ var elapsedtime = 0;
 var altTens = 0;
 var altPolarity = "";
 var track_diff = 0;
-var AICenter = nil; # FPV
+var AICenter = nil;
 
 # Fetch nodes:
 var state1 = props.globals.getNode("/systems/thrust/state1", 1);
@@ -138,7 +138,6 @@ var adr_1_fault = props.globals.getNode("/controls/navigation/adirscp/lights/adr
 var adr_2_fault = props.globals.getNode("/controls/navigation/adirscp/lights/adr-2-fault", 1);
 var adr_3_fault = props.globals.getNode("/controls/navigation/adirscp/lights/adr-3-fault", 1);
 var air_data_switch = props.globals.getNode("/controls/navigation/switching/air-data", 1);
-var alpha = props.globals.getNode("/fdm/jsbsim/aero/alpha-deg", 1); # TODO - Is this used anywhere?
 
 # Create Nodes:
 var alt_diff = props.globals.initNode("/instrumentation/pfd/alt-diff", 0.0, "DOUBLE");
@@ -150,7 +149,7 @@ var horizon_ground = props.globals.initNode("/instrumentation/pfd/horizon-ground
 var hdg_diff = props.globals.initNode("/instrumentation/pfd/hdg-diff", 0.0, "DOUBLE");
 var hdg_scale = props.globals.initNode("/instrumentation/pfd/heading-scale", 0.0, "DOUBLE");
 var track = props.globals.initNode("/instrumentation/pfd/track-deg", 0.0, "DOUBLE");
-#var track_diff = props.globals.initNode("/instrumentation/pfd/track-hdg-diff", 0.0, "DOUBLE"); # returns incorrect value and can calculate on the fly
+#var track_diff = props.globals.initNode("/instrumentation/pfd/track-hdg-diff", 0.0, "DOUBLE"); # returns incorrect value
 var du1_test = props.globals.initNode("/instrumentation/du/du1-test", 0, "BOOL");
 var du1_test_time = props.globals.initNode("/instrumentation/du/du1-test-time", 0.0, "DOUBLE");
 var du1_offtime = props.globals.initNode("/instrumentation/du/du1-off-time", 0.0, "DOUBLE");
@@ -1028,7 +1027,7 @@ var canvas_PFD_base = {
 		me["AI_heading"].update();
 	},
 	
-	# Dim the yellow outline of fixed aircraft symbol on PFDs (eg when crew select TRK)
+	# Dim the yellow outline of fixed aircraft symbol on PFDs (when crew select TRK-FPA)
 	# 1 == dim 
 	# 0 == undim
 	dimFixedAircraftOutline: func(dim_bool) {
@@ -1136,8 +1135,7 @@ var canvas_PFD_1 = {
 			me["FD_pitch"].hide();
 		}
 		
-		# FPV
-		# If TRK FPA selected on the FCU, display FPV on PFD1
+		# If TRK FPA selected, display FPV on PFD1
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
 			me.dimFixedAircraftOutline(0);
@@ -1148,24 +1146,10 @@ var canvas_PFD_1 = {
 				me.dimFixedAircraftOutline(0);
 			} else {
 				var roll_deg = roll.getValue() or 0; 
-				var alpha_deg = aoa;
-				var fpa_deg = pitch.getValue() - alpha_deg;
-
 				AICenter = me["AI_center"].getCenter();
 				var track_x_translation = me.getTrackDiffPixels(track_diff); 
 
-				# Display FPV in red if FPA greater or less plus or minus 9.9 degrees
-				# if (fpa_deg > 9.9) {
-				# 	alpha_deg = alpha_deg + (fpa_deg - 9.9);
-				# 	me["FPV"].setColor(1, 0, 0);
-				# } else if (fpa_deg < -9.9) {
-				# 	alpha_deg = alpha_deg + (fpa_deg + 9.9);
-				# 	me["FPV"].setColor(1, 0, 0);
-				# } else {
-				# 	me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
-				# }
-
-				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(alpha_deg, -20, 20) * 12.5); 
+				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(aoa, -20, 20) * 12.5); 
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);
 				me["FPV"].setRotation(roll_deg * D2R); # It shouldn't be rotated, only the axis should be
 				me["FPV"].show();
@@ -1912,8 +1896,7 @@ var canvas_PFD_2 = {
 			me["FD_pitch"].hide();
 		}
 		
-		# FPV
-		# If TRK FPA selected on the FCU, display FPV on PFD2
+		# If TRK FPA selected, display FPV on PFD2
 		if (ap_trk_sw.getValue() == 0 ) {
 			me["FPV"].hide();	
 			me.dimFixedAircraftOutline(0);
@@ -1923,25 +1906,11 @@ var canvas_PFD_2 = {
 				me["FPV"].hide();	
 				me.dimFixedAircraftOutline(0);
 			} else {
-				var roll_deg = roll.getValue() or 0;
-				var alpha_deg = aoa;
-				var fpa_deg = pitch.getValue() - alpha_deg;
-	
+				var roll_deg = roll.getValue() or 0;	
 				AICenter = me["AI_center"].getCenter();
 				var track_x_translation = me.getTrackDiffPixels(track_diff);
 
-				# Display FPV in red if FPA greater or less plus or minus 9.9 degrees
-				# if (fpa_deg > 9.9) {
-				# 	alpha_deg = alpha_deg + (fpa_deg - 9.9);
-				# 	me["FPV"].setColor(1, 0, 0);
-				# } else if (fpa_deg < -9.9) {
-				# 	alpha_deg = alpha_deg + (fpa_deg + 9.9);
-				# 	me["FPV"].setColor(1, 0, 0);
-				# } else {
-				# 	me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
-				# }
-
-				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(alpha_deg, -20, 20) * 12.5);
+				me.AI_fpv_trans.setTranslation(track_x_translation, math.clamp(aoa, -20, 20) * 12.5);
 				me.AI_fpv_rot.setRotation(-roll_deg * D2R, AICenter);
 				me["FPV"].setRotation(roll_deg * D2R); # It shouldn't be rotated, only the axis should be
 				me["FPV"].show();

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -976,13 +976,15 @@ var canvas_PFD_base = {
 			me["HDG_target"].hide();
 		}
 		
-		track_diff = geo.normdeg180(track.getValue() - heading.getValue());
+
+		var heading_deg = heading.getValue();
+		track_diff = geo.normdeg180(track.getValue() - heading_deg);
 		me["TRK_pointer"].setTranslation(me.getTrackDiffPixels(track_diff),0);
 		split_ils = split("/", ils_data1.getValue());
 		
 		if (ap_ils_mode.getValue() == 1 and size(split_ils) == 2) {
 			magnetic_hdg = ils_crs.getValue();
-			magnetic_hdg_dif = geo.normdeg180(magnetic_hdg - heading.getValue());
+			magnetic_hdg_dif = geo.normdeg180(magnetic_hdg - heading_deg);
 			if (magnetic_hdg_dif >= -23.62 and magnetic_hdg_dif <= 23.62) {
 				me["CRS_pointer"].setTranslation((magnetic_hdg_dif / 10) * 98.5416, 0);
 				me["ILS_HDG_R"].hide();

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -1160,16 +1160,16 @@ var canvas_PFD_1 = {
 		} else {
 			var aoa = me.getAOAForPFD1();	
 			if (aoa == nil or (systems.ADIRS.ADIRunits[0].aligned != 1 and att_switch.getValue() == 0) or (systems.ADIRS.ADIRunits[2].aligned != 1 and att_switch.getValue() == -1)){
-				me["FPV"].setTranslation(0, 0);
-				me["FPV"].setColor(1, 0, 0);
+				me["FPV"].hide();	
+				me.dimFixedAircraftOutline(0);
 			} else {
 				var track_x_translation = me.getTrackDiffPixels(track_diff); 
 				var fpa_deg = pitch.getValue() - aoa;
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
-				me["FPV"].setColor(0.050980392, 0.752941176, 0.290196078);	
+				me["FPV"].show();
+				me.dimFixedAircraftOutline(1);
 			}
-			me["FPV"].show();
-			me.dimFixedAircraftOutline(1);
+
 		}
 
 		# ILS
@@ -1918,16 +1918,15 @@ var canvas_PFD_2 = {
 		} else {
 			var aoa = me.getAOAForPFD2();
 			if (aoa == nil or (systems.ADIRS.ADIRunits[1].aligned != 1 and att_switch.getValue() == 0) or (systems.ADIRS.ADIRunits[2].aligned != 1 and att_switch.getValue() == 1)) {
-				me["FPV"].setTranslation(0, 0);
-				me["FPV"].setColor(1, 0, 0);
+				me["FPV"].hide();	
+				me.dimFixedAircraftOutline(0);
 			} else {
 				var track_x_translation = me.getTrackDiffPixels(track_diff);
 				var fpa_deg = pitch.getValue() - aoa;
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
-				me["FPV"].setColor(0.050980392, 0.752941176, 0.290196078);	
+				me["FPV"].show();
+				me.dimFixedAircraftOutline(1);
 			}
-			me["FPV"].show();
-			me.dimFixedAircraftOutline(1);
 		}
 
 		# ILS

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -976,7 +976,7 @@ var canvas_PFD_base = {
 		}
 		
 		track_diff = track.getValue() - heading.getValue();
-		me["TRK_pointer"].setTranslation((math.clamp(track_diff, -23.62, 23.62) / 10) * 98.5416, 0);
+		me["TRK_pointer"].setTranslation(me.getTrackDiffPixels(track_diff),0);
 		split_ils = split("/", ils_data1.getValue());
 		
 		if (ap_ils_mode.getValue() == 1 and size(split_ils) == 2) {
@@ -1026,7 +1026,7 @@ var canvas_PFD_base = {
 		me["AI_heading"].update();
 	},
 	
-	# dim the yellow outline of fixed aircraft symbol on PFDs
+	# Dim the yellow outline of fixed aircraft symbol on PFDs
 	# eg when crew select TRK
 	# 1 == dim 
 	# 0 == undim
@@ -1074,6 +1074,12 @@ var canvas_PFD_base = {
 		
 		return pitch_y_translation + ((-1) * fpa_y_translation);
 
+	},
+
+	# Convert difference between magnetic heading and track measured in degrees to pixel for display on PFDs
+	# And set max and minimum values
+	getTrackDiffPixels: func(track_diff_deg) {
+		return ((math.clamp(track_diff_deg, -23.62, 23.62) / 10) * 98.5416);
 	},
 
 
@@ -1157,7 +1163,7 @@ var canvas_PFD_1 = {
 				me["FPV"].setTranslation(0, 0);
 				me["FPV"].setColor(1, 0, 0);
 			} else {
-				var track_x_translation = (math.clamp(track_diff, -23.62, 23.62) / 10) * 98.5416; 
+				var track_x_translation = me.getTrackDiffPixels(track_diff); 
 				var fpa_deg = pitch.getValue() - aoa;
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
 				me["FPV"].setColor(0.050980392, 0.752941176, 0.290196078);	
@@ -1915,7 +1921,7 @@ var canvas_PFD_2 = {
 				me["FPV"].setTranslation(0, 0);
 				me["FPV"].setColor(1, 0, 0);
 			} else {
-				var track_x_translation = (math.clamp(track_diff, -23.62, 23.62) / 10) * 98.5416; 
+				var track_x_translation = me.getTrackDiffPixels(track_diff);
 				var fpa_deg = pitch.getValue() - aoa;
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
 				me["FPV"].setColor(0.050980392, 0.752941176, 0.290196078);	

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -1165,6 +1165,12 @@ var canvas_PFD_1 = {
 			} else {
 				var track_x_translation = me.getTrackDiffPixels(track_diff); 
 				var fpa_deg = pitch.getValue() - aoa;
+				if (fpa_deg > 9.9 or fpa_deg < -9.9) {
+					fpa_deg = math.clamp(fpa_deg, -9.9, 9.9);
+					me["FPV"].setColor(1, 0, 0);
+				} else {
+					me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
+				}
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
 				me["FPV"].show();
 				me.dimFixedAircraftOutline(1);
@@ -1923,6 +1929,12 @@ var canvas_PFD_2 = {
 			} else {
 				var track_x_translation = me.getTrackDiffPixels(track_diff);
 				var fpa_deg = pitch.getValue() - aoa;
+				if (fpa_deg > 9.9 or fpa_deg < -9.9) {
+					fpa_deg = math.clamp(fpa_deg, -9.9, 9.9);
+					me["FPV"].setColor(1, 0, 0);
+				} else {
+					me["FPV"].setColor(0.066666667, 0.752941176, 0.294117647);
+				}
 				me["FPV"].setTranslation(track_x_translation, me.getFPVYTranslation(track_x_translation, fpa_deg));
 				me["FPV"].show();
 				me.dimFixedAircraftOutline(1);

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -15,6 +15,7 @@ var updateR = 0;
 var elapsedtime = 0;
 var altTens = 0;
 var altPolarity = "";
+var FPV_Y_COEFFICIENT = 12.5;
 
 # Fetch nodes:
 var state1 = props.globals.getNode("/systems/thrust/state1", 1);
@@ -126,6 +127,9 @@ var inner_marker = props.globals.getNode("/instrumentation/marker-beacon/inner",
 var flap_config = props.globals.getNode("/controls/flight/flaps-input", 1);
 var hundredAbove = props.globals.getNode("/instrumentation/pfd/hundred-above", 1);
 var minimum = props.globals.getNode("/instrumentation/pfd/minimums", 1);
+var aoa_1 = props.globals.getNode("/systems/navigation/adr/output/aoa-1", 1);
+var aoa_2 = props.globals.getNode("/systems/navigation/adr/output/aoa-2", 1);
+var aoa_3 = props.globals.getNode("/systems/navigation/adr/output/aoa-3", 1);
 
 # Create Nodes:
 var alt_diff = props.globals.initNode("/instrumentation/pfd/alt-diff", 0.0, "DOUBLE");
@@ -212,7 +216,7 @@ var canvas_PFD_base = {
 		"AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","ALT_box_flash","ALT_box","ALT_box_amber","ALT_scale","ALT_target","ALT_target_digit","ALT_one","ALT_two","ALT_three","ALT_four","ALT_five","ALT_digits","ALT_tens","ALT_digit_UP",
 		"ALT_digit_DN","ALT_error","ALT_group","ALT_group2","ALT_frame","VS_pointer","VS_box","VS_digit","VS_error","VS_group","QNH","QNH_setting","QNH_std","QNH_box","LOC_pointer","LOC_scale","GS_scale","GS_pointer","CRS_pointer","HDG_target","HDG_scale",
 		"HDG_one","HDG_two","HDG_three","HDG_four","HDG_five","HDG_six","HDG_seven","HDG_digit_L","HDG_digit_R","HDG_error","HDG_group","HDG_frame","TRK_pointer","machError","ilsError","ils_code","ils_freq","dme_dist","dme_dist_legend","ILS_HDG_R","ILS_HDG_L",
-		"ILS_right","ILS_left","outerMarker","middleMarker","innerMarker","v1_group","v1_text","vr_speed","F_target","S_target","FS_targets","flap_max","clean_speed","ground","ground_ref"];
+		"ILS_right","ILS_left","outerMarker","middleMarker","innerMarker","v1_group","v1_text","vr_speed","F_target","S_target","FS_targets","flap_max","clean_speed","ground","ground_ref","FPV"];
 	},
 	updateDu1: func() {
 		var elapsedtime_act = elapsedtime.getValue();
@@ -1079,6 +1083,17 @@ var canvas_PFD_1 = {
 			me["FD_pitch"].hide();
 		}
 		
+		# FPV
+		# If TRK FPA selected on the FCU, display FPV on PFD1
+		# TODO - Deal with situation if AOA not available from ADR1
+		# TODO - Hide FPV if error on PFD1
+		if (ap_trk_sw.getValue() == 0) {
+			me["FPV"].hide();	
+		} else {
+			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, math.clamp(aoa_1.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT);
+			me["FPV"].show();
+		}
+
 		# ILS
 		if (ap_ils_mode.getValue() == 1) {
 			me["LOC_scale"].show();
@@ -1817,6 +1832,17 @@ var canvas_PFD_2 = {
 			me["FD_pitch"].hide();
 		}
 		
+		# FPV
+		# If TRK FPA selected on the FCU, display FPV on PFD2
+		# TODO - Deal with situation if AOA not available from ADR2
+		# TODO - Hide FPV if error on PFD2
+		if (ap_trk_sw.getValue() == 0) {
+			me["FPV"].hide();	
+		} else {
+			me["FPV"].setTranslation((math.clamp(track_diff.getValue(), -23.62, 23.62) / 10) * 98.5416, math.clamp(aoa_2.getValue(), -9.9, 9.9)*FPV_Y_COEFFICIENT);
+			me["FPV"].show();
+		}
+
 		# ILS
 		if (ap_ils_mode2.getValue() == 1) {
 			me["LOC_scale"].show();

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -977,7 +977,7 @@ var canvas_PFD_base = {
 			me["HDG_target"].hide();
 		}
 		
-		track_diff = track.getValue() - heading.getValue();
+		track_diff = geo.normdeg180(track.getValue() - heading.getValue());
 		me["TRK_pointer"].setTranslation(me.getTrackDiffPixels(track_diff),0);
 		split_ils = split("/", ils_data1.getValue());
 		

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -8,7 +8,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="pfd.svg"
-   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   inkscape:version="1.0 (262b4497e3, 2020-09-04)"
    id="svg2"
    version="1.1"
    viewBox="0 0 1024 1024"
@@ -39,15 +39,15 @@
      showguides="true"
      inkscape:current-layer="svg2"
      inkscape:window-maximized="1"
-     inkscape:window-y="23"
+     inkscape:window-y="0"
      inkscape:window-x="0"
-     inkscape:cy="886.5494"
-     inkscape:cx="916.44902"
-     inkscape:zoom="2.1546825"
+     inkscape:cy="686.37792"
+     inkscape:cx="635.80596"
+     inkscape:zoom="4.309365"
      showgrid="true"
      id="namedview371"
-     inkscape:window-height="1035"
-     inkscape:window-width="1920"
+     inkscape:window-height="835"
+     inkscape:window-width="1600"
      inkscape:pageshadow="2"
      inkscape:pageopacity="1"
      guidetolerance="10"
@@ -6658,9 +6658,35 @@
        x="61.095329"
        y="74.429939"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">FLX</tspan></text>
-  <path
-     style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:5.877913;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 447.59808,482.4841 v 9.38782 h 1.06691 v -9.38782 z m 0.38115,12.7416 a 16.427645,16.427645 0 0 0 -16.42755,16.42754 16.427645,16.427645 0 0 0 16.42755,16.42754 16.427645,16.427645 0 0 0 16.42754,-16.42754 16.427645,16.427645 0 0 0 -16.42754,-16.42754 z m -54.20078,16.02956 v 0.35359 h 36.64816 v -0.35359 z m 71.88043,0.35359 v 0.35512 h 36.64664 v -0.35512 z"
-     id="FPV"
-     inkscape:connector-curvature="0" />
+  <g
+     id="FPV">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:5.92816;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1861"
+       cx="447.75107"
+       cy="513.21716"
+       r="15.372474" />
+    <rect
+       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:6.225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1865"
+       width="38.245033"
+       height="6.3569298"
+       x="392.05685"
+       y="509.83191" />
+    <rect
+       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:6.225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1869"
+       width="38.245033"
+       height="6.3569298"
+       x="465.55685"
+       y="509.83191" />
+    <rect
+       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:3.94089;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1871"
+       width="14.447689"
+       height="6.7442465"
+       x="-495.71423"
+       y="444.54013"
+       transform="rotate(-90)" />
+  </g>
 </svg>

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -6656,4 +6656,9 @@
        x="61.095329"
        y="74.429939"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">FLX</tspan></text>
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:5.877913;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 447.59808,482.4841 v 9.38782 h 1.06691 v -9.38782 z m 0.38115,12.7416 a 16.427645,16.427645 0 0 0 -16.42755,16.42754 16.427645,16.427645 0 0 0 16.42755,16.42754 16.427645,16.427645 0 0 0 16.42754,-16.42754 16.427645,16.427645 0 0 0 -16.42754,-16.42754 z m -54.20078,16.02956 v 0.35359 h 36.64816 v -0.35359 z m 71.88043,0.35359 v 0.35512 h 36.64664 v -0.35512 z"
+     id="FPV"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -1396,9 +1396,10 @@
       <path
          sodipodi:nodetypes="cccccccccccc"
          inkscape:connector-curvature="0"
-         id="rect4760-1"
+         id="fixed_aircraft_outline_1"
          d="m 279.39676,473.84829 20.67975,-1.3e-4 v 15.43882 0 l 1.8e-4,25.65723 h -15.4389 l -0.14628,-25.65723 v 0 l -81.2588,-5e-5 v -15.43891 l 76.16405,2.1e-4 z"
-         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="fixed_aircraft_outline_1" />
     </g>
     <g
        id="g4856"
@@ -1420,9 +1421,10 @@
       <path
          style="fill:none;fill-opacity:1;stroke:#c9d121;stroke-width:3.54375;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 279.39676,473.84829 20.67975,-1.3e-4 v 15.43882 0 l 1.8e-4,25.65723 h -15.4389 l -0.14628,-25.65723 v 0 l -81.2588,-5e-5 v -15.43891 l 76.16405,2.1e-4 z"
-         id="path4854"
+         id="fixed_aircraft_outline_2"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccc" />
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:label="fixed_aircraft_outline_2" />
     </g>
     <path
        style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.19995;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:fill markers stroke"

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -46,8 +46,8 @@
      inkscape:zoom="6.0943624"
      showgrid="true"
      id="namedview371"
-     inkscape:window-height="1015"
-     inkscape:window-width="1920"
+     inkscape:window-height="835"
+     inkscape:window-width="1600"
      inkscape:pageshadow="2"
      inkscape:pageopacity="1"
      guidetolerance="10"
@@ -6660,35 +6660,35 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">FLX</tspan></text>
   <g
      id="FPV"
-     style="stroke:#11c04b;stroke-opacity:1"
-     transform="translate(0.03412367,-0.04316723)">
-    <circle
-       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:5.92816;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path1861"
-       cx="448.1662"
-       cy="513.59192"
-       r="15.372474" />
+     inkscape:label="#g4866"
+     transform="translate(4.3177635,10.931087)">
     <rect
-       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:4.42405;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1869"
-       width="40.045986"
-       height="3.0663724"
-       x="465.87289"
-       y="511.68826" />
+       transform="rotate(90)"
+       style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:4.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4864"
+       width="12.8"
+       height="4.7999878"
+       x="471.06799"
+       y="-446.19958" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#00ff00;stroke-width:4.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 460.89737,502.24844 c 0,9.44871 -7.65969,17.1084 -17.1084,17.1084 -9.44871,0 -17.1084,-7.65969 -17.1084,-17.1084 0,-9.44871 7.65969,-17.1084 17.1084,-17.1084 9.44871,0 17.1084,7.65969 17.1084,17.1084 z"
+       id="path4858"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zzzzz" />
     <rect
-       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:4.42405;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect2947"
-       width="40.045986"
-       height="3.0663724"
-       x="389.94388"
-       y="511.68826" />
+       y="499.80042"
+       x="412.66745"
+       height="4.7999878"
+       width="12.8"
+       id="rect4860"
+       style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:4.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect
-       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:3.82266;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect2956"
-       width="18.900246"
-       height="3.3959746"
-       x="479.94556"
-       y="-449.89334"
-       transform="rotate(90)" />
+       style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:4.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4862"
+       width="12.8"
+       height="4.7999878"
+       x="462.13199"
+       y="499.80042" />
   </g>
 </svg>

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -46,8 +46,8 @@
      inkscape:zoom="6.0943624"
      showgrid="true"
      id="namedview371"
-     inkscape:window-height="835"
-     inkscape:window-width="1600"
+     inkscape:window-height="1015"
+     inkscape:window-width="1920"
      inkscape:pageshadow="2"
      inkscape:pageopacity="1"
      guidetolerance="10"
@@ -6659,7 +6659,9 @@
        y="74.429939"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.9995px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.657577">FLX</tspan></text>
   <g
-     id="FPV">
+     id="FPV"
+     style="stroke:#11c04b;stroke-opacity:1"
+     transform="translate(0.03412367,-0.04316723)">
     <circle
        style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:5.92816;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path1861"

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -8,7 +8,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="pfd.svg"
-   inkscape:version="1.0 (262b4497e3, 2020-09-04)"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
    id="svg2"
    version="1.1"
    viewBox="0 0 1024 1024"
@@ -41,9 +41,9 @@
      inkscape:window-maximized="1"
      inkscape:window-y="0"
      inkscape:window-x="0"
-     inkscape:cy="686.37792"
-     inkscape:cx="635.80596"
-     inkscape:zoom="4.309365"
+     inkscape:cy="681.99254"
+     inkscape:cx="587.65082"
+     inkscape:zoom="6.0943624"
      showgrid="true"
      id="namedview371"
      inkscape:window-height="835"
@@ -6661,32 +6661,32 @@
   <g
      id="FPV">
     <circle
-       style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:5.92816;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:5.92816;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path1861"
-       cx="447.75107"
-       cy="513.21716"
+       cx="448.1662"
+       cy="513.59192"
        r="15.372474" />
     <rect
-       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:6.225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1865"
-       width="38.245033"
-       height="6.3569298"
-       x="392.05685"
-       y="509.83191" />
-    <rect
-       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:6.225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:4.42405;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect1869"
-       width="38.245033"
-       height="6.3569298"
-       x="465.55685"
-       y="509.83191" />
+       width="40.045986"
+       height="3.0663724"
+       x="465.87289"
+       y="511.68826" />
     <rect
-       style="fill:#0dc04b;fill-opacity:1;stroke:none;stroke-width:3.94089;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1871"
-       width="14.447689"
-       height="6.7442465"
-       x="-495.71423"
-       y="444.54013"
-       transform="rotate(-90)" />
+       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:4.42405;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2947"
+       width="40.045986"
+       height="3.0663724"
+       x="389.94388"
+       y="511.68826" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#11c04b;stroke-width:3.82266;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2956"
+       width="18.900246"
+       height="3.3959746"
+       x="479.94556"
+       y="-449.89334"
+       transform="rotate(90)" />
   </g>
 </svg>


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
If user selects TRK-FPA, display FPV on PFD1 and PFD2. 

FPVs on PFD1 and PFD2 are based on ADR1 and ADR2 respectively.

FPV only displayed if ADIRS is aligned and available. If ADR1 or ADR2 is not available but ADR3 is, ADR3 can be selected via ATT switch on switching panel.

Based on FPV code from MD11 (as recommended by legoboy).

Also fixes bug with trk pointer - which always incorrectly displayed 0.

This is my first attempt at writing code for FlightGear. Merspieler suggested/encouraged me to give it a go and suggested this feature. Also provided feedback and suggestions on initial attempts. I have attempted to follow the same coding  style as existing code. Having said that I am still get my head around the best way to write code (eg when to get values from other Nasal objects rather than the property tree).

Unfortunately I don't have access to images of an actual FPV on a PFD - so I estimated the dimensions based on diagrams in the FCOM.

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
