### PR TITLE
Changes in Simbrief import, ND display, MCDU, PERFTO, CLR button

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1918,20 +1918,37 @@
 			<key n="8">
 				<name>Del</name>
 				<desc>CLR</desc>
+				<repeatable type="bool">true</repeatable>
 				<binding>
 					<condition>
 						<property>/FMGC/keyboard-left</property>
 					</condition>
 					<command>nasal</command>
-					<script>mcdu.button("CLR", 0);</script>
+					<script>mcdu.button("CLR", 0, "down");</script>
 				</binding>
 				<binding>
 					<condition>
 						<property>/FMGC/keyboard-right</property>
 					</condition>
 					<command>nasal</command>
-					<script>mcdu.button("CLR", 1);</script>
+					<script>mcdu.button("CLR", 1, "down");</script>
 				</binding>
+				<mod-up>
+					<binding>
+						<condition>
+							<property>/FMGC/keyboard-left</property>
+						</condition>
+						<command>nasal</command>
+						<script>mcdu.button("CLR", 0, "up");</script>
+					</binding>
+					<binding>
+						<condition>
+							<property>/FMGC/keyboard-right</property>
+						</condition>
+						<command>nasal</command>
+						<script>mcdu.button("CLR", 1, "up");</script>
+					</binding>
+				</mod-up>
 			</key>
 			<key n="11">
 				<name>Disable MCDU keyboard mode</name>

--- a/AircraftConfig/acconfig.nas
+++ b/AircraftConfig/acconfig.nas
@@ -196,10 +196,14 @@ var renderingSettings = {
 	check: func() {
 		var rembrandt = getprop("/sim/rendering/rembrandt/enabled");
 		var ALS = getprop("/sim/rendering/shaders/skydome");
-		var customSettings = getprop("/sim/rendering/shaders/custom-settings") == 1;
+
+		#CHECKME : it's ok with quality-level >= 3 - ( quality-level == -1 if custom-settings == true )
+		
+		#var customSettings = getprop("/sim/rendering/shaders/custom-settings") == 1;  #CHECKME - it's a bool
 		var landmass = getprop("/sim/rendering/shaders/landmass") >= 4;
 		var model = getprop("/sim/rendering/shaders/model") >= 2;
-		if (!rembrandt and (!ALS or !customSettings or !landmass or !model)) {
+		#if (!rembrandt and (!ALS or !customSettings or !landmass or !model)) {  #CHECKME - imho, unchecked customSettings it's boring when quality-level >= 3
+		if (!rembrandt and (!ALS or !landmass or !model)) {
 			rendering_dlg.open();
 		}
 	},
@@ -255,6 +259,15 @@ var writeSettings = func {
 # Panel States #
 ################
 
+# Abort auto-config and close dialog
+var abortPanelStates = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 1) {
+		setprop("/systems/acconfig/autoconfig-running", 0);
+	}
+	ps_load_dlg.close();
+	spinning.stop();
+}
+
 # Cold and Dark
 var colddark = func {
 	if (getprop("/systems/acconfig/mismatch-code") == "0x000") {
@@ -301,6 +314,7 @@ var colddark = func {
 	}
 }
 var colddark_b = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 0) return 0; # auto-config aborted
 	# Continues the Cold and Dark script, after engines fully shutdown.
 	setprop("/controls/apu/master", 0);
 	settimer(func {
@@ -351,6 +365,7 @@ var beforestart = func {
 	}
 }
 var beforestart_b = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 0) return 0; # auto-config aborted
 	# Continue with engine start prep.
 	systems.FUEL.Switches.pumpLeft1.setValue(1);
 	systems.FUEL.Switches.pumpLeft2.setValue(1);
@@ -438,6 +453,7 @@ var taxi = func {
 	}
 }
 var taxi_b = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 0) return 0; # auto-config aborted
 	# Continue with engine start prep, and start engines.
 	systems.FUEL.Switches.pumpLeft1.setValue(1);
 	systems.FUEL.Switches.pumpLeft2.setValue(1);
@@ -491,6 +507,7 @@ var taxi_b = func {
 	settimer(taxi_c, 2);
 }
 var taxi_c = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 0) return 0; # auto-config aborted
 	setprop("/controls/engines/engine-start-switch", 2);
 	setprop("/controls/engines/engine[0]/cutoff-switch", 0);
 	setprop("/controls/engines/engine[1]/cutoff-switch", 0);
@@ -499,6 +516,7 @@ var taxi_c = func {
 	}, 10);
 }
 var taxi_d = func {
+	if (getprop("/systems/acconfig/autoconfig-running") == 0) return 0; # auto-config aborted
 	# After Start items.
 	setprop("/controls/engines/engine-start-switch", 1);
 	setprop("/controls/apu/master", 0);

--- a/AircraftConfig/psload.xml
+++ b/AircraftConfig/psload.xml
@@ -37,6 +37,16 @@
 				<property>/systems/acconfig/spin</property>
 				<live>1</live>
 			</text>
+			<button>
+				<halign>center</halign>
+				<legend>Abort</legend>
+				<pref-width>160</pref-width>
+				<key>Esc</key>
+				<binding>
+					<command>nasal</command>
+					<script>acconfig.abortPanelStates();</script>
+				</binding>
+			</button>			
 			
 		</group>
 	

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -155,6 +155,8 @@ var pageProp = [props.globals.getNode("/MCDU[0]/page", 1), props.globals.getNode
 var active = [props.globals.getNode("/MCDU[0]/active", 1), props.globals.getNode("/MCDU[1]/active", 1)];
 var activeAtsu = [props.globals.getNode("/MCDU[0]/atsu-active", 1), props.globals.getNode("/MCDU[1]/atsu-active", 1)];
 
+var reqFMGC = [0,0]; # flag = 1 when REQ is show
+
 # Conversion factor pounds to kilogram
 var LBS2KGS = 0.4535924;
 
@@ -198,23 +200,23 @@ var canvas_MCDU_base = {
 		me["PERFTO_FE"].setFont(symbol);
 		me["PERFTO_SE"].setFont(symbol);
 		me["PERFTO_OE"].setFont(symbol);
-		me["PERFTO_FE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFTO_SE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFTO_OE"].setColor(0.8078,0.8039,0.8078);
+		me["PERFTO_FE"].setColor(BLUE);
+		me["PERFTO_SE"].setColor(BLUE);
+		me["PERFTO_OE"].setColor(BLUE);
 		
 		me["PERFAPPR_FE"].setFont(symbol);
 		me["PERFAPPR_SE"].setFont(symbol);
 		me["PERFAPPR_OE"].setFont(symbol);
-		me["PERFAPPR_FE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFAPPR_SE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFAPPR_OE"].setColor(0.8078,0.8039,0.8078);
+		me["PERFAPPR_FE"].setColor(BLUE);
+		me["PERFAPPR_SE"].setColor(BLUE);
+		me["PERFAPPR_OE"].setColor(BLUE);
 		
 		me["PERFGA_FE"].setFont(symbol);
 		me["PERFGA_SE"].setFont(symbol);
 		me["PERFGA_OE"].setFont(symbol);
-		me["PERFGA_FE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFGA_SE"].setColor(0.8078,0.8039,0.8078);
-		me["PERFGA_OE"].setColor(0.8078,0.8039,0.8078);
+		me["PERFGA_FE"].setColor(BLUE);
+		me["PERFGA_SE"].setColor(BLUE);
+		me["PERFGA_OE"].setColor(BLUE);
 		
 		me.page = canvas_group;
 		
@@ -280,7 +282,7 @@ var canvas_MCDU_base = {
 		me["PERFTO"].hide();
 	},
 	defaultPageNumbers: func() {
-		me["Simple_Title"].setColor(1, 1, 1);
+		me["Simple_Title"].setColor(WHITE);
 		me["Simple_PageNum"].setText("X/X");
 		me["Simple_PageNum"].hide();
 		me["ArrowLeft"].hide();
@@ -497,29 +499,42 @@ var canvas_MCDU_base = {
 				me.standardFontColour();
 				me["Simple_L3"].setText(" AIDS");
 				me["Simple_L4"].setText(" CFDS");
+
 				pageSwitch[i].setBoolValue(1);
 			}
 			
-			if (active[i].getValue() == 0) {
+			if (active[i].getValue() == 0 and reqFMGC[i] == 0) {
 				me["Simple_L1"].setText(" FMGC");
-				me["Simple_L1"].setColor(1,1,1);
+				me["Simple_L1"].setColor(GREEN);  # from yt seems starts GREEN
+				me["Simple_L1_Arrow"].setColor(GREEN); # color arrow too
+				reqFMGC[i] = 1;					
+				settimer(func {
+					if (active[i].getValue() == 0) { #only on REQ phase
+						me["Simple_L1"].setText(" FMGC (REQ)");
+					}
+				},1.4); #delay estimated
 			} else if (active[i].getValue() == 1) {
-				me["Simple_L1"].setText(" FMGC(SEL)");
-				me["Simple_L1"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L1"].setText(" FMGC (SEL)"); # space added
+				me["Simple_L1"].setColor(BLUE);
+				me["Simple_L1_Arrow"].setColor(BLUE); # color arrow too
 			} else if (active[i].getValue() == 2) {
 				me["Simple_L1"].setText(" FMGC");
-				me["Simple_L1"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_L1"].setColor(GREEN);
+				me["Simple_L1_Arrow"].setColor(GREEN); # color arrow too
 			}
 			
 			if (activeAtsu[i].getValue() == 0) {
 				me["Simple_L2"].setText(" ATSU");
-				me["Simple_L2"].setColor(1,1,1);
+				me["Simple_L2"].setColor(WHITE);
+				me["Simple_L2_Arrow"].setColor(WHITE); # color arrow too
 			} else if (activeAtsu[i].getValue() == 1) {
-				me["Simple_L2"].setText(" ATSU(SEL)");
-				me["Simple_L2"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L2"].setText(" ATSU (SEL)"); #space added
+				me["Simple_L2"].setColor(BLUE);
+				me["Simple_L2_Arrow"].setColor(BLUE); # color arrow too
 			} else if (activeAtsu[i].getValue() == 2) {
 				me["Simple_L2"].setText(" ATSU");
-				me["Simple_L2"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_L2"].setColor(GREEN);
+				me["Simple_L2_Arrow"].setColor(GREEN); # color arrow too
 			}
 		} else if (page == "ATSUDLINK") {
 			if (!pageSwitch[i].getBoolValue()) {
@@ -912,7 +927,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHide();
 				me["Simple_Title"].setText("ATC MENU");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("1/2");
 				me["Simple_PageNum"].show();
 				me["ArrowLeft"].show();
@@ -958,7 +973,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHideWithCenter();
 				me["Simple_Title"].setText("TEXT");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("1/2");
 				me["Simple_PageNum"].show();
 				me["ArrowLeft"].show();
@@ -1049,7 +1064,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHideWithCenter();
 				me["Simple_Title"].setText("ATC MENU");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("2/2");
 				me["Simple_PageNum"].show();
 				me["ArrowLeft"].show();
@@ -1146,7 +1161,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHideWithCenter();
 				me["Simple_Title"].setText("ATS623 ATIS MENU");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].hide();
 				me["ArrowLeft"].hide();
 				me["ArrowRight"].hide();
@@ -1907,7 +1922,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHide();
 				me["Simple_Title"].setText("DATA INDEX");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("1/2");
 				me["Simple_PageNum"].show();
 				me["ArrowLeft"].show();
@@ -1947,7 +1962,7 @@ var canvas_MCDU_base = {
 			if (!pageSwitch[i].getBoolValue()) {
 				me.defaultHide();
 				me["Simple_Title"].setText("DATA INDEX");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("2/2");
 				me["Simple_PageNum"].show();
 				me["ArrowLeft"].show();
@@ -2228,7 +2243,7 @@ var canvas_MCDU_base = {
 				me["PERFGA"].hide();
 				me["Simple_Title"].show();
 				me["Simple_Title"].setText("INIT");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
 				me["ArrowLeft"].show();
@@ -2272,12 +2287,12 @@ var canvas_MCDU_base = {
 			
 			if (!fmgc.FMGCInternal.toFromSet and !fmgc.FMGCInternal.costIndexSet) {
 				me["INITA_CostIndex"].hide();
-				me["Simple_L5"].setColor(1,1,1);
+				me["Simple_L5"].setColor(WHITE);
 				me["Simple_L5"].show();
 				me["Simple_L5"].setText("---");
 			} else if (fmgc.FMGCInternal.costIndexSet) {
 				me["INITA_CostIndex"].hide();
-				me["Simple_L5"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L5"].setColor(BLUE);
 				me["Simple_L5"].show();
 				me["Simple_L5"].setText(sprintf("%s", fmgc.FMGCInternal.costIndex));
 			} else {
@@ -2286,28 +2301,40 @@ var canvas_MCDU_base = {
 			}
 			if (!fmgc.FMGCInternal.toFromSet and !fmgc.FMGCInternal.crzSet) {
 				me["INITA_CruiseFLTemp"].hide();
-				me["Simple_L6"].setColor(1,1,1);
+				me["Simple_L6"].setColor(WHITE);
 				me["Simple_L6"].setText("-----/---g");
 			} else if (fmgc.FMGCInternal.crzSet and fmgc.FMGCInternal.crzTempSet) {
 				me["INITA_CruiseFLTemp"].hide();
-				me["Simple_L6"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L6"].setColor(BLUE);
 				me["Simple_L6"].setText(sprintf("%s", "FL" ~ fmgc.FMGCInternal.crzFl) ~ sprintf("/%sg", fmgc.FMGCInternal.crzTemp));
 			} else if (fmgc.FMGCInternal.crzSet) {
 				me["INITA_CruiseFLTemp"].hide();
-				me["Simple_L6"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L6"].setColor(BLUE);
 				fmgc.FMGCInternal.crzTemp = 15 - (2 * fmgc.FMGCInternal.crzFl / 10);
 				fmgc.FMGCInternal.crzTempSet = 1;
 				me["Simple_L6"].setText(sprintf("%s", "FL" ~ fmgc.FMGCInternal.crzFl) ~ sprintf("/%sg", fmgc.FMGCInternal.crzTemp));
 			} else {
 				me["INITA_CruiseFLTemp"].show();
-				me["Simple_L6"].setColor(0.7333,0.3803,0);
+				me["Simple_L6"].setColor(AMBER);
 				me["Simple_L6"].setText("         g");
 			}
+
+			if (fmgc.FMGCInternal.coRouteSet) { # show coRoute when valid
+				me["INITA_CoRoute"].hide();
+				me["Simple_L1"].setText(fmgc.FMGCInternal.coRoute);
+				me["Simple_L1"].setColor(BLUE);
+				me["Simple_L1"].show();
+			} else {
+				me["Simple_L1"].hide();
+				me["INITA_CoRoute"].show();				
+				me["Simple_L1"].setText("NONE");
+			}
+
 			if (fmgc.FMGCInternal.toFromSet) {
 				me["INITA_CoRoute"].hide();
 				me["INITA_FromTo"].hide();
 				me["Simple_L1"].show();
-				me["Simple_L2"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L2"].setColor(BLUE);
 				if (fmgc.FMGCInternal.altAirportSet) {
 					me["Simple_L2"].setText(fmgc.FMGCInternal.altAirport);
 				} else {
@@ -2320,7 +2347,7 @@ var canvas_MCDU_base = {
 				me["INITA_CoRoute"].show();
 				me["INITA_FromTo"].show();
 				me["Simple_L1"].hide();
-				me["Simple_L2"].setColor(1,1,1);
+				me["Simple_L2"].setColor(WHITE);
 				me["Simple_L2"].setText("----/----------");
 				me.showRight(-1, 1, 0, 0, 0, 0);
 				me["Simple_R2S"].show();
@@ -2364,7 +2391,7 @@ var canvas_MCDU_base = {
 			me["Simple_L3S"].setText("FLT NBR");
 			me["Simple_L5S"].setText("COST INDEX");
 			me["Simple_L6S"].setText("CRZ FL/TEMP");
-			me["Simple_L1"].setText("NONE");
+			#me["Simple_L1"].setText("NONE");  # manage before (coRoute)
 			me["Simple_L3"].setText(sprintf("%s", fmgc.FMGCInternal.flightNum));
 			me["Simple_R1S"].setText("FROM/TO   ");
 			me["Simple_R2S"].setText("INIT ");
@@ -2666,7 +2693,7 @@ var canvas_MCDU_base = {
 			me["Simple_R5"].setText(fmgc.FMGCInternal.tripWind);
 			me["Simple_R6S"].setText("EXTRA/TIME");
 			
-			me["Simple_Title"].setColor(1, 1, 1);
+			me["Simple_Title"].setColor(WHITE);
 			
 			if (!fmgc.FMGCInternal.fuelRequest) {
 				me["Simple_L2"].setText("---.-/----");
@@ -2706,7 +2733,7 @@ var canvas_MCDU_base = {
 				me["Simple_R6"].setText("---.-/----");
 				
 				me["Simple_Title"].setText("INIT");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				
 				me.colorLeft("ack", "wht", "wht", "wht", "wht", "wht");
 				me.colorRight("ack", "blu", "amb", "wht", "ack", "wht");
@@ -3059,7 +3086,7 @@ var canvas_MCDU_base = {
 				me["PERFGA"].hide();
 				me["Simple_Title"].show();
 				me["Simple_Title"].setText("FUEL PRED");
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
 				me["ArrowLeft"].show();
@@ -3387,7 +3414,7 @@ var canvas_MCDU_base = {
 				}
 				
 				me["Simple_Title"].show();
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 				me["Simple_PageNum"].setText("X/X");
 				me["Simple_PageNum"].hide();
 				me["ArrowLeft"].hide();
@@ -3570,9 +3597,9 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 1) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 			}
 			
 			if (fmgc.flightPlanController.flightplans[2].departure_runway != nil) {
@@ -3701,7 +3728,7 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 2) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 				me.showLeft(0, 0, 0, 0, 1, 0);
 				me.showLeftS(0, 0, 0, 0, 1, 0);
 				me.showLeftArrow(0, 0, 0, 0, 1, 1);
@@ -3742,7 +3769,7 @@ var canvas_MCDU_base = {
 					setprop("/FMGC/internal/activate-twice", 0);
 				}
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me.showLeft(0, 0, 0, 0, -1, 0);
 				me.showLeftS(0, 0, 0, 0, -1, 0);
 				me.showLeftArrow(0, 0, 0, 0, -1, 0);
@@ -3776,10 +3803,10 @@ var canvas_MCDU_base = {
 			
 			me["Simple_L2S"].setText(" CI");
 			if (fmgc.FMGCInternal.costIndexSet) {
-				me["Simple_L2"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L2"].setColor(BLUE);
 				me["Simple_L2"].setText(sprintf(" %s", fmgc.FMGCInternal.costIndex));
 			} else {
-				me["Simple_L2"].setColor(1,1,1);
+				me["Simple_L2"].setColor(WHITE);
 				me["Simple_L2"].setText(" ---");
 			}
 			
@@ -3854,7 +3881,7 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 3) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 
 				if (managedSpeed.getValue() == 1) {
 					me.showLeft(0, 0, 0, -1, 0, 0);
@@ -3889,7 +3916,7 @@ var canvas_MCDU_base = {
 					setprop("/FMGC/internal/activate-twice", 0);
 				}
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				
 				me.colorLeft("ack", "ack", "ack", "ack", "ack", "wht");
 				me.colorLeftS("ack", "ack", "ack", "ack", "ack", "wht");
@@ -3916,10 +3943,10 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.costIndexSet) {
-				me["Simple_L2"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L2"].setColor(BLUE);
 				me["Simple_L2"].setText(sprintf(" %s", fmgc.FMGCInternal.costIndex));
 			} else {
-				me["Simple_L2"].setColor(1,1,1);
+				me["Simple_L2"].setColor(WHITE);
 				me["Simple_L2"].setText(" ---");
 			}
 			
@@ -3992,7 +4019,7 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 4) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 				me.showLeft(0, 0, 0, 0, 1, 0);
 				me.showRight(0, 1, 0, 1, 0, 0);
 				me.showRightS(0, 0, 1, 0, 0, 0);
@@ -4032,7 +4059,7 @@ var canvas_MCDU_base = {
 					setprop("/FMGC/internal/activate-twice", 0);
 				}
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 				me.showLeft(0, 0, 0, 0, -1, 0);
 				me.showRight(0, -1, 0, -1, 0, 0);
 				me.showRightS(0, 0, -1, 0, 0, 0);
@@ -4064,10 +4091,10 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.costIndexSet) {
-				me["Simple_L2"].setColor(0.0901,0.6039,0.7176);
+				me["Simple_L2"].setColor(BLUE);
 				me["Simple_L2"].setText(sprintf(" %2.0f", fmgc.FMGCInternal.costIndex));
 			} else {
-				me["Simple_L2"].setColor(1,1,1);
+				me["Simple_L2"].setColor(WHITE);
 				me["Simple_L2"].setText(" ---");
 			}
 			
@@ -4148,9 +4175,9 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 5) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 			}
 			
 			me["Simple_L0S"].setText("DEST");
@@ -4331,9 +4358,9 @@ var canvas_MCDU_base = {
 			}
 			
 			if (fmgc.FMGCInternal.phase == 6) {
-				me["Simple_Title"].setColor(0.0509,0.7529,0.2941);
+				me["Simple_Title"].setColor(GREEN);
 			} else {
-				me["Simple_Title"].setColor(1, 1, 1);
+				me["Simple_Title"].setColor(WHITE);
 			}
 			
 			if (thrAccSet.getValue() == 1) {
@@ -5967,6 +5994,8 @@ setlistener("sim/signals/fdm-initialized", func {
 	
 	mcdu.mcdu_message(0, "SELECT DESIRED SYSTEM");
 	mcdu.mcdu_message(1, "SELECT DESIRED SYSTEM");
+
+	reqFMGC = [0,0]; # reset FMGC REQ status - on MCDU restart
 	
 	MCDU_update.start();
 });

--- a/Models/Instruments/MCDU/MCDU1.xml
+++ b/Models/Instruments/MCDU/MCDU1.xml
@@ -1705,7 +1705,7 @@
 			<repeatable>true</repeatable>
 			<binding>
 				<command>nasal</command>
-				<script>mcdu.button("CLR", 0);</script>
+				<script>mcdu.button("CLR", 0, "down");</script>
 				<condition>
 					<and>
 						<greater-than-equals>
@@ -1719,6 +1719,24 @@
 					</and>
 				</condition>
 			</binding>
+			<mod-up>
+				<binding>
+					<command>nasal</command>
+					<script>mcdu.button("CLR", 0, "up");</script>
+					<condition>
+						<and>
+							<greater-than-equals>
+								<property>systems/electrical/bus/ac-1</property>
+								<value>110</value>
+							</greater-than-equals>
+							<greater-than>
+								<property>controls/lighting/DU/mcdu1</property>
+								<value>0.01</value>
+							</greater-than>
+						</and>
+					</condition>
+				</binding>
+			</mod-up>
 		</action>
 	</animation>
 	<animation>

--- a/Models/Instruments/MCDU/MCDU2.xml
+++ b/Models/Instruments/MCDU/MCDU2.xml
@@ -1705,7 +1705,7 @@
 			<repeatable>true</repeatable>
 			<binding>
 				<command>nasal</command>
-				<script>mcdu.button("CLR", 1);</script>
+				<script>mcdu.button("CLR", 1, "down");</script>
 				<condition>
 					<and>
 						<greater-than-equals>
@@ -1719,6 +1719,24 @@
 					</and>
 				</condition>
 			</binding>
+			<mod-up>
+				<binding>
+					<command>nasal</command>
+					<script>mcdu.button("CLR", 1, "up");</script>
+					<condition>
+						<and>
+							<greater-than-equals>
+								<property>systems/electrical/bus/ac-2</property>
+								<value>110</value>
+							</greater-than-equals>
+							<greater-than>
+								<property>controls/lighting/DU/mcdu2</property>
+								<value>0.01</value>
+							</greater-than>
+						</and>
+					</condition>
+				</binding>
+			</mod-up>
 		</action>
 	</animation>
 	<animation>

--- a/Models/Instruments/ND/canvas/map/WPT-airbus.lcontroller
+++ b/Models/Instruments/ND/canvas/map/WPT-airbus.lcontroller
@@ -75,17 +75,26 @@ var WPTModel = {
 	new: func(fp, idx) {
 		var m = { parents:[WPTModel] };
 		var wp = fp.getWP(idx);
+		var wpprev = (idx>0) ? fp.getWP(idx-1) : nil;
 
 		m.id = wp.id;
 		m.name = wp.wp_name;
-		m.alt = wp.alt_cstr;
-		m.spd = wp.speed_cstr;
+		if (wpprev != nil) {
+			m.alt = (wp.alt_cstr > 0 and wpprev.alt_cstr != wp.alt_cstr) ? wp.alt_cstr : 0 ; # display on change
+			m.spd = (wp.speed_cstr > 0 and wpprev.speed_cstr != wp.speed_cstr) ? wp.speed_cstr : 0; # display on change
+		} else {
+			m.alt = (wp.alt_cstr > 0) ? wp.alt_cstr : 0 ; # display if valid
+			m.spd = (wp.speed_cstr > 0) ? wp.speed_cstr : 0; # display if valid
+		}
+
 		m.type = wp.wp_type;
 
 		(m.lat,m.lon) = (wp.wp_lat,wp.wp_lon);
 		var is_rwy = (m.type == 'runway');
 		var id_len = size(m.id);
-		if(!is_rwy and id_len < 5){
+		if (left(m.name,1) == "(") {  # check for pseudo waypoints (T/D) (T/C) (DECEL) (LIM) ...
+			m.navtype = 'vnav';
+		} else if(!is_rwy and id_len < 5){
 			if(id_len == 4 and airportinfo(m.id) != nil)
 				m.navtype = 'airport';
 			else {

--- a/Models/Instruments/ND/canvas/map/WPT-airbus.symbol
+++ b/Models/Instruments/ND/canvas/map/WPT-airbus.symbol
@@ -35,103 +35,112 @@ var init = func {
 		draw_sym = me.options.vor_symbol;
 	elsif(navtype == 'ndb')
 		draw_sym = me.options.ndb_symbol;
+	elsif(navtype == 'vnav') # pseudo waypoints not visible
+		draw_sym = nil;
 	else
 		draw_sym = me.options.fix_symbol;
-	me.wp_sym = me.element.createChild('group', 'wp-'~ me.model.idx);
-	if(typeof(draw_sym) == 'func')
-		draw_sym(me.wp_sym);
-	elsif(typeof(draw_sym) == 'scalar')
-		canvas.parsesvg(me.wp_sym, draw_sym);
-	var translation = me.getStyle('translation', {});
-	if(contains(translation, navtype)){
-		me.wp_sym.setTranslation(translation[navtype]);
-	}
-	me.text_wps = wp_group.createChild("text", "wp-text-" ~ me.model.idx)
-	.setDrawMode( canvas.Text.TEXT )
-	.setText(me.model.name)
-	.setFont("LiberationFonts/LiberationSans-Regular.ttf")
-	.setFontSize(28)
-	.setTranslation(25,15)
-	.setColor(1,1,1);
-	me.text_alt = nil;
-	if(alt > 0 or spd > 0){
-		var cstr_txt = "\n";
-		if(alt > 0){
-			if(alt > 10000) 
-				cstr_txt ~= sprintf('FL%3d', int(alt / 100));
-			else 
-				cstr_txt ~= sprintf('%4d', int(alt));
+
+	me.wp_sym = nil;
+
+	if (draw_sym != nil) { # init only on valid symbol
+		me.wp_sym = me.element.createChild('group', 'wp-'~ me.model.idx); 
+		if(typeof(draw_sym) == 'func')
+			draw_sym(me.wp_sym);
+		elsif(typeof(draw_sym) == 'scalar')
+			canvas.parsesvg(me.wp_sym, draw_sym);
+		var translation = me.getStyle('translation', {});
+		if(contains(translation, navtype)){
+			me.wp_sym.setTranslation(translation[navtype]);
 		}
-		if(spd > 0){
-			if(alt > 0) cstr_txt ~= "\n";
-			if(spd <= 1) 
-				cstr_txt ~= sprintf('%4.2fM', spd);
-			else 
-				cstr_txt ~= sprintf('%3dKT', int(spd));
-		}
-		me.text_alt = wp_group.createChild("text", "wp-alt-text-" ~ me.model.idx)
+		me.text_wps = wp_group.createChild("text", "wp-text-" ~ me.model.idx)
 		.setDrawMode( canvas.Text.TEXT )
-		.setText(cstr_txt)
+		.setText(me.model.name)
 		.setFont("LiberationFonts/LiberationSans-Regular.ttf")
 		.setFontSize(28)
-		.setTranslation(25,15);
+		.setTranslation(25,15)
+		.setColor(1,1,1);
+		me.text_alt = nil;
+		if(alt > 0 or spd > 0){
+			var cstr_txt = "\n";
+			if(alt > 0){
+				if(alt > 10000) 
+					cstr_txt ~= sprintf('FL%3d', int(alt / 100));
+				else 
+					cstr_txt ~= sprintf('%4d', int(alt));
+			}
+			if(spd > 0){
+				if(alt > 0) cstr_txt ~= "\n";
+				if(spd <= 1) 
+					cstr_txt ~= sprintf('%4.2fM', spd);
+				else 
+					cstr_txt ~= sprintf('%3dKT', int(spd));
+			}
+			me.text_alt = wp_group.createChild("text", "wp-alt-text-" ~ me.model.idx)
+			.setDrawMode( canvas.Text.TEXT )
+			.setText(cstr_txt)
+			.setFont("LiberationFonts/LiberationSans-Regular.ttf")
+			.setFontSize(28)
+			.setTranslation(25,15);
+		}
 	}
 }
 
 var draw = func{
-	var wp_group = me.element;
-	var alt = me.model.alt;
-	var i = me.model.idx;
-	var vnav_actv = getprop(me.options.ver_ctrl) == me.options.managed_val;
-	var curwp = getprop(me.options.current_wp);
-	if(alt > 0){
-		var wp_d = me.model.wp.distance_along_route;
-		var lvl_off_at = getprop(me.options.level_off_alt);
-		if(lvl_off_at == nil) lvl_off_at = 0;
-		if(me.alt_path == nil){
-			me.alt_path = wp_group.createChild("path").
-			setStrokeLineWidth(4).
-			moveTo(-22,0).
-			arcSmallCW(22,22,0,44,0).
-			arcSmallCW(22,22,0,-44,0);
-		}
-		if(vnav_actv){
-			if(lvl_off_at and (lvl_off_at - wp_d) > 0.5 and curwp == i)
-				me.alt_path.setColor(me.missed_constraint_color);
+	if (me.wp_sym != nil) { # draw only valid symbol
+		var wp_group = me.element;
+		var alt = me.model.alt;
+		var i = me.model.idx;
+		var vnav_actv = getprop(me.options.ver_ctrl) == me.options.managed_val;
+		var curwp = getprop(me.options.current_wp);
+		if(alt > 0){
+			var wp_d = me.model.wp.distance_along_route;
+			var lvl_off_at = getprop(me.options.level_off_alt);
+			if(lvl_off_at == nil) lvl_off_at = 0;
+			if(me.alt_path == nil){
+				me.alt_path = wp_group.createChild("path").
+				setStrokeLineWidth(4).
+				moveTo(-22,0).
+				arcSmallCW(22,22,0,44,0).
+				arcSmallCW(22,22,0,-44,0);
+			}
+			if(vnav_actv){
+				if(lvl_off_at and (lvl_off_at - wp_d) > 0.5 and curwp == i)
+					me.alt_path.setColor(me.missed_constraint_color);
+				else
+					me.alt_path.setColor(me.active_constraint_color);
+			}
 			else
-				me.alt_path.setColor(me.active_constraint_color);
-		}
-		else
-			me.alt_path.setColor(me.constraint_color);
-		if(me.layer.toggle_cstr)
-			me.alt_path.show();
-		else
-			me.alt_path.hide();
-	} else {
-		if(me.alt_path != nil) me.alt_path.hide();
-	}
-	wp_group.set("z-index",4);
-	#var sym = me.element.getElementById('wp-' ~ me.model.idx);
-	if(alt > 0 and me.text_alt != nil){
-		if(vnav_actv)
-			me.text_alt.setColor(me.active_constraint_color);
-		else
-			me.text_alt.setColor(me.constraint_color);
-	}
-	if(i == curwp) {
-		me.wp_sym.setColor(me.current_wp_color);
-		me.text_wps.setColor(me.current_wp_color);
-	} else {
-		me.wp_sym.setColor(me.wp_color);
-		me.text_wps.setColor(me.wp_color);
-	}
-	if(me.model.is_departure or me.model.is_destination){
-		var prop = (me.model.is_departure ? 'departure' : 'destination');
-		var rwy = getprop("/autopilot/route-manager/"~prop~"/runway");
-		if(rwy != nil and size(rwy) > 0){
-			me.wp_sym.hide();
+				me.alt_path.setColor(me.constraint_color);
+			if(me.layer.toggle_cstr)
+				me.alt_path.show();
+			else
+				me.alt_path.hide();
 		} else {
-			me.wp_sym.show();
+			if(me.alt_path != nil) me.alt_path.hide();
+		}
+		wp_group.set("z-index",4);
+		#var sym = me.element.getElementById('wp-' ~ me.model.idx);
+		if(alt > 0 and me.text_alt != nil){
+			if(vnav_actv)
+				me.text_alt.setColor(me.active_constraint_color);
+			else
+				me.text_alt.setColor(me.constraint_color);
+		}
+		if(i == curwp) {
+			me.wp_sym.setColor(me.current_wp_color);
+			me.text_wps.setColor(me.current_wp_color);
+		} else {
+			me.wp_sym.setColor(me.wp_color);
+			me.text_wps.setColor(me.wp_color);
+		}
+		if(me.model.is_departure or me.model.is_destination){
+			var prop = (me.model.is_departure ? 'departure' : 'destination');
+			var rwy = getprop("/autopilot/route-manager/"~prop~"/runway");
+			if(rwy != nil and size(rwy) > 0){
+				me.wp_sym.hide();
+			} else {
+				me.wp_sym.show();
+			}
 		}
 	}
 }

--- a/Nasal/FMGC/FMGC-b.nas
+++ b/Nasal/FMGC/FMGC-b.nas
@@ -288,6 +288,7 @@ var ITAF = {
 			if (Gear.wow1Temp and Gear.wow2Temp) {
 				Text.lat.setValue("RLOU");
 				Text.vert.setValue("ROLLOUT");
+				fcu.apOff("soft", 0); # soft disangage AP if plane touch the ground (eg. on ILS autoland)
 			}
 		}
 		

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -169,6 +169,8 @@ var FMGCInternal = {
 	altAirportSet: 0,
 	altSelected: 0,
 	arrApt: "",
+	coRoute: "",
+	coRouteSet: 0,
 	costIndex: 0,
 	costIndexSet: 0,
 	crzFt: 10000,
@@ -309,6 +311,7 @@ var updateArptLatLon = func {
 
 updateRouteManagerAlt = func() {
 	setprop("autopilot/route-manager/cruise/altitude-ft", FMGCInternal.crzFt);
+	# TODO - update FMGCInternal.phase when DES to re-enter in CLIMB/CRUIZE
 };
 
 ########
@@ -625,7 +628,7 @@ var masterFMGC = maketimer(0.2, func {
 	
 	if (FMGCInternal.phase == 1 and ((mode != "SRS" and mode != " ") or alt >= accel_agl_ft)) {
 		FMGCInternal.phase = 2;
-		systems.PNEU.pressMode.setValue("TO");
+		systems.PNEU.pressMode.setValue("TO"); # TODO - why not set to CL (climb) ??
 	}
 	
 	if (FMGCInternal.phase == 2 and (mode == "ALT CRZ" or mode == "ALT CRZ*")) {

--- a/Nasal/FMGC/SimbriefParser.nas
+++ b/Nasal/FMGC/SimbriefParser.nas
@@ -1,5 +1,6 @@
 # A3XX Simbrief Parser
 # Copyright (c) 2020 Jonathan Redpath (legoboyvdlp)
+# enhanceded 12/2020 - parse TOD & TOC psedo waypoints, set computer speeds on fix wps, fake coRoute name
 
 var LBS2KGS = 0.4535924;
 
@@ -157,12 +158,16 @@ var SimbriefParser = {
 			
 			if (ident == "TOC") {
 				_foundTOC = 1;
-				continue;
+				setprop("/autopilot/route-manager/vnav/tc/latitude-deg",ofpFix.getNode("pos_lat").getValue());
+				setprop("/autopilot/route-manager/vnav/tc/longitude-deg",ofpFix.getNode("pos_long").getValue());				
+				ident = "(T/C)";
 			}
 			
 			if (ident == "TOD") {
 				_foundTOD = 1;
-				continue;
+				setprop("/autopilot/route-manager/vnav/td/latitude-deg",ofpFix.getNode("pos_lat").getValue());
+				setprop("/autopilot/route-manager/vnav/td/longitude-deg",ofpFix.getNode("pos_long").getValue());
+				ident = "(T/D)";
 			}
 			
 			coords = geo.Coord.new();
@@ -189,6 +194,34 @@ var SimbriefParser = {
 			fmgc.flightPlanController.flightplans[3].star = _star;
 		}
 		fmgc.flightPlanController.destroyTemporaryFlightPlan(3, 1);
+
+        var idx = 1;
+		var plan = fmgc.flightPlanController.flightplans[2];
+		var altitude = "";
+		var speed = "";
+		var wpname = "";
+
+		foreach (var ofpFix; ofpFixes) {
+			ident = ofpFix.getNode("ident").getValue();			
+
+			if (ident == "TOC") wpname = "(T/C)";
+			else if (ident == "TOD") wpname = "(T/D)";
+			else wpname = ident;
+
+			wp = plan.getWP(idx); # get leg	
+			if (wp != nil) {
+				if (wp.wp_name == wpname) {
+					altitude = ofpFix.getNode("altitude_feet").getValue();
+					speed = ofpFix.getNode("ind_airspeed").getValue();
+
+					if (speed>0) wp.setSpeed(speed, "computed");
+					if (altitude>0) wp.setAltitude(math.round(altitude, 10), "computed");
+
+					idx = idx + 1;			
+				}
+			}
+		}
+
 		fmgc.windController.updatePlans();
 		fmgc.updateRouteManagerAlt();
 		
@@ -199,6 +232,8 @@ var SimbriefParser = {
 		if (me.buildFlightplan() == nil) {
 			return nil;
 		}
+		fmgc.FMGCInternal.coRoute = "SB" ~ me.OFP.getNode("origin/iata_code").getValue() ~ me.OFP.getNode("destination/iata_code").getValue() ~ "00";
+		fmgc.FMGCInternal.coRouteSet = 1;
 		fmgc.FMGCInternal.flightNum = (me.OFP.getNode("general/icao_airline").getValue() or "") ~ (me.OFP.getNode("general/flight_number").getValue() or "");
 		fmgc.FMGCInternal.flightNumSet = 1;
 		fmgc.FMGCInternal.costIndex = me.OFP.getNode("general/costindex").getValue();

--- a/Nasal/FMGC/flightplan.nas
+++ b/Nasal/FMGC/flightplan.nas
@@ -389,11 +389,22 @@ var flightPlanController = {
 	deleteWP: func(index, n, a = 0, s = 0) { # a = 1, means adding a waypoint via deleting intermediate. s = 1, means autosequencing
 		var wp = wpID[n][index].getValue();
 		if (((s == 0 and left(wp, 4) != FMGCInternal.depApt and left(wp, 4) != FMGCInternal.arrApt) or (s == 1)) and me.flightplans[n].getPlanSize() > 2) {
-			if (me.flightplans[n].getWP(index).id != "DISCONTINUITY" and a == 0) { # if it is a discont, don't make a new one
+			var _wpid = me.flightplans[n].getWP(index).id;
+			if (left(_wpid,1)=="(") { # pseudo waypoint
+			    var _vnav = "";
+				if (_wpid == "(T/C)") _vnav = "tc";
+				else if (_wpid == "(T/D)") _vnav = "td";
+				if (_vnav) {
+					setprop("/autopilot/route-manager/vnav/" ~ _vnav ~ "/latitude-deg",0);  # hide pseudo wp symbol on ND
+					setprop("/autopilot/route-manager/vnav/" ~ _vnav ~ "/longitude-deg",0);						
+				}
+				me.flightplans[n].deleteWP(index);
+				fmgc.windController.deleteWind(n, index);
+			} else if (_wpid != "DISCONTINUITY" and a == 0) { # if it is a discont, don't make a new one
 				me.flightplans[n].deleteWP(index);
 				fmgc.windController.deleteWind(n, index);
 				if (me.flightplans[n].getWP(index) != nil and s == 0) {
-					if (me.flightplans[n].getWP(index).id != "DISCONTINUITY") { # else, if the next one isn't a discont, add one
+					if (_wpid != "DISCONTINUITY") { # else, if the next one isn't a discont, add one
 						me.addDiscontinuity(index, n);
 					}
 				}

--- a/Nasal/FMGC/mcdu-messages.nas
+++ b/Nasal/FMGC/mcdu-messages.nas
@@ -69,6 +69,7 @@ var scratchpadController = {
 		sp.scratchpadColour = "wht";
 		sp.showTypeIMsg = 0;
 		sp.showTypeIIMsg = 0;
+		sp.clrmode = 0; # 1 = CLR mode
 		sp.mcdu = mcdu;
 		return sp;
 	},
@@ -88,6 +89,11 @@ var scratchpadController = {
 			me.clearTypeI();
 		}
 		
+		if (me.clrmode == 1) { # prevent add chars in CLR mode
+			me.clear();			
+		}
+	    else if (character == "CLR") me.clrmode = 1;
+
 		me.scratchpad = me.scratchpad ~ character;
 		me.scratchpadColour = "wht";
 		me.update();
@@ -140,6 +146,7 @@ var scratchpadController = {
 	},
 	empty: func() {
 		me.scratchpad = "";
+		me.clrmode = 0;
 		me.update();
 	},
 	clear: func() {

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -5,7 +5,40 @@
 
 var initInputA = func(key, i) {
 	var scratchpad = mcdu_scratchpad.scratchpads[i].scratchpad;
-	if (key == "L2") {
+	if (key == "L1") { #clear coRoute if set
+		if (scratchpad == "CLR") {
+			if (fmgc.FMGCInternal.coRouteSet == 1) {
+				fmgc.FMGCInternal.coRouteSet = 0;
+				fmgc.FMGCInternal.coRoute = "";
+				fmgc.FMGCInternal.depApt = "";
+				fmgc.FMGCInternal.arrApt = "";
+				fmgc.FMGCInternal.toFromSet = 0;
+				fmgc.FMGCNodes.toFromSet.setValue(0);
+				fmgc.windController.resetDesWinds();
+				setprop("/FMGC/internal/align-ref-lat", 0);
+				setprop("/FMGC/internal/align-ref-long", 0);
+				setprop("/FMGC/internal/align-ref-lat-edit", 0);
+				setprop("/FMGC/internal/align-ref-long-edit", 0);
+				if (fmgc.FMGCInternal.blockConfirmed) {
+					fmgc.FMGCInternal.fuelCalculating = 0;
+					fmgc.fuelCalculating.setValue(0);
+					fmgc.FMGCInternal.fuelCalculating = 1;
+					fmgc.fuelCalculating.setValue(1);
+				}
+				fmgc.flightPlanController.reset(2);
+				fmgc.flightPlanController.init();
+				Simbrief.SimbriefParser.inhibit = 0;				
+			}
+			mcdu_scratchpad.scratchpads[i].empty();
+		} else {
+			var len = size(scratchpad);
+			if (fmgc.FMGCInternal.coRouteSet == 1 or len != 10) {
+				mcdu_message(i, "NOT ALLOWED");
+			} else {
+				mcdu_message(i, "NOT IN DATA BASE");  # fake message - TODO flightplan loader
+			}
+		}
+	} else if (key == "L2") {
 		if (scratchpad == "CLR") {
 			fmgc.FMGCInternal.altAirport = "";
 			fmgc.FMGCInternal.altAirportSet = 0;
@@ -183,7 +216,10 @@ var initInputA = func(key, i) {
 			}
 		}
 	} else if (key == "R1") {
-		if (scratchpad == "CLR") {
+		if (fmgc.FMGCInternal.coRouteSet == 1) {
+			mcdu_message(i, "NOT ALLOWED");
+		}
+		else if (scratchpad == "CLR") {
 			fmgc.FMGCInternal.depApt = "";
 			fmgc.FMGCInternal.arrApt = "";
 			fmgc.FMGCInternal.toFromSet = 0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -75,6 +75,8 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.gndTempSet = 0;
 	fmgc.FMGCInternal.toFromSet = 0;
 	fmgc.FMGCNodes.toFromSet.setValue(0);
+	fmgc.FMGCInternal.coRoute = "";
+	fmgc.FMGCInternal.coRouteSet = 0;
 	fmgc.FMGCInternal.tropo = 36090;
 	fmgc.FMGCInternal.tropoSet = 0;
 	
@@ -1484,7 +1486,9 @@ var pagebutton = func(btn, i) {
 	}
 }
 
-var button = func(btn, i) {
+var buttonCLRDown = [0,0]; # counter for down event
+
+var button = func(btn, i, event = "") {
 	page = pageNode[i].getValue();
 	if (page != "MCDU") {
 		var scratchpad = mcdu_scratchpad.scratchpads[i].scratchpad;
@@ -1493,11 +1497,24 @@ var button = func(btn, i) {
 		} else if (btn == "SP") {
 			mcdu_scratchpad.scratchpads[i].addChar(" ");
 		} else if (btn == "CLR") {
-			var scratchpad = mcdu_scratchpad.scratchpads[i].scratchpad;
-			if (size(scratchpad) == 0) {
-				mcdu_scratchpad.scratchpads[i].addChar("CLR");
-			} else {
-				mcdu_scratchpad.scratchpads[i].clear();
+			if (event == "down") {
+				if (size(scratchpad) > 0) {
+					if (buttonCLRDown[i] > 4) {
+						mcdu_scratchpad.scratchpads[i].empty();
+					}
+					buttonCLRDown[i] = buttonCLRDown[i] + 1;
+				}
+			}
+			else if (event == "" or buttonCLRDown[i]<=4) {
+				buttonCLRDown[i] = 0;
+				#var scratchpad = mcdu_scratchpad.scratchpads[i].scratchpad;  <- useless??
+				if (size(scratchpad) == 0) {
+					mcdu_scratchpad.scratchpads[i].addChar("CLR");
+				} else {
+					mcdu_scratchpad.scratchpads[i].clear();
+				}
+			} else {  # up with buttonCLRDown[i]>4
+				buttonCLRDown[i] = 0;
 			}
 		} else if (btn == "DOT") {
 			mcdu_scratchpad.scratchpads[i].addChar(".");
@@ -1511,6 +1528,12 @@ var button = func(btn, i) {
 
 var mcdu_message = func(i, string, overrideStr = "") {
 	mcdu_scratchpad.scratchpads[i].showTypeI(mcdu_scratchpad.MessageController.getTypeIMsgByText(string));
+	mcdu_scratchpad.scratchpads[i].override(overrideStr);
+}
+
+# Messagge Type II - TODO 5 messages queue  - remove only on resolve
+var mcdu_messageTypeII = func(i, string, overrideStr = "") {
+	mcdu_scratchpad.scratchpads[i].showTypeII(mcdu_scratchpad.MessageController.getTypeIIMsgByText(string));
 	mcdu_scratchpad.scratchpads[i].override(overrideStr);
 }
 


### PR DESCRIPTION
Adding some features about real FMS (Honeywell), I check on manual and yt videos.
Implement import of pseudo waypoints from Simbrief and speed/alt computed data.
Thanks for your great work to port A320 on Flightgear, I hope you enjoy my contribution.

### Description of Changes
- long pressing CLR button (keyboard/MCDU panel) clears scratchpad (not works on MCDU dialog)
- Simbrief import adding TOC/TOD pseudo-waypoints and speed/alt for all waypoints
- Basic manage of coRoute
- ND displays TOC/TOD and speed/alt constraints
- abort button for panel state dialog, when error occurs on state script, you can't close panel
- fix MCDU starting page, arrow color and REQ state (https://youtu.be/twwUjHXdNVU?t=57)
- PERFTO, validation on insert of V1/Vr/V2 values and type II error messages
- PERFTO, basic validation of THRRED/ACC

### Screenshots (optional)
none, sorry

### Bugs fixed (if any)
- prevent fix graphics settings dialog on false positive when custom-setting is off and quality-level >= 3
- "soft" auto-pilot disengage on roll-out phase (ILS landing)

### Checklist:
* [x] My changes follow the Contributing Guidelines.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.
* [x] My changes are ready for merging.
