### PR TITLE
Remove ready to merge checkbox, replace with draft pull request.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,5 @@
 * [ ] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
 * [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
 * [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
-* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->
+
+<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->


### PR DESCRIPTION
### Description of Changes
Instead of using the "My changes are ready for merging" checkbox, we can just add a reminder to tell everyone that if their changes are ready, to create pull request, and if they are not, create a draft pull request

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
