### PR TITLE
FCU: Change HDG and ALT display formatting

### DIFF
--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -4535,8 +4535,8 @@
 		</offsets>
 		<alignment>center-center</alignment>
 		<axis-alignment>xy-plane</axis-alignment>
-		<type type="string">text-value</type>
-		<format type="string">%s</format>
+		<type type="string">number-value</type>
+		<format type="string">%03.0f</format>
 		<property>it-autoflight/input/hdg</property>
 		<truncate>false</truncate>
 		<font type="string">led.txf</font>
@@ -4587,8 +4587,8 @@
 		</offsets>
 		<alignment>center-center</alignment>
 		<axis-alignment>xy-plane</axis-alignment>
-		<type type="string">text-value</type>
-		<format type="string">%s</format>
+		<type type="string">number-value</type>
+		<format type="string">%05.0f</format>
 		<property>it-autoflight/input/alt</property>
 		<truncate>false</truncate>
 		<font type="string">led.txf</font>


### PR DESCRIPTION
Show select HDG always with 3 digits (if select HDG < 100 with leading 0)

Show selected ALT always with 5 digits.

### Description of Changes
The real FCU seems to always show 3 digits for the heading. Same with the altitude where always 5 digits are displayed

See:
* https://youtu.be/Rap0hBaxm-0?t=407
* https://youtu.be/UKABHGDWg0Q?t=54
* many other cockpit videos

### Checklist:
* [X] My changes follow the Contributing Guidelines.
* [X] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.

