### PR TITLE
Systems: Don't allow ignition if no fuel pump is running

### DIFF
--- a/Systems/a320-ignition.xml
+++ b/Systems/a320-ignition.xml
@@ -68,8 +68,9 @@
 		<!-- Engine 1 -->
 		<switch name="/systems/ignition/can-run-1">
 			<default value="0"/>
-			<test value="1">
+			<test logic="AND" value="1">
 				propulsion/tank[5]/contents-lbs ge 1
+				/systems/fuel/pumps/all-eng-pump-off eq 0
 			</test>
 		</switch>
 		
@@ -195,8 +196,9 @@
 		<!-- Engine 2 -->
 		<switch name="/systems/ignition/can-run-2">
 			<default value="0"/>
-			<test value="1">
+			<test logic="AND" value="1">
 				propulsion/tank[6]/contents-lbs ge 1
+				/systems/fuel/pumps/all-eng-pump-off eq 0
 			</test>
 		</switch>
 		


### PR DESCRIPTION
Currently, it is possible to start engines WITHOUT any fuel pump running.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [X] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->