### PR TITLE
Remove the hardcoded canvas texture indexes

### DIFF
--- a/gui/dialogs/mcdu1-dlg.xml
+++ b/gui/dialogs/mcdu1-dlg.xml
@@ -179,11 +179,20 @@
 			<nasal>
 				<load>
 					<![CDATA[
+						var textureIndex = 15;
+						foreach (var texture; props.globals.getNode("/canvas/by-index").getChildren("texture")) {
+							var name = texture.getChild("name");
+							if (name != nil and name.getValue() == "MCDU1") {
+								textureIndex = texture.getIndex();
+								break;
+							}
+						}
+
 						var mcdu_canvas_dlg = canvas.get(cmdarg());
 						var root = mcdu_canvas_dlg.createGroup();
 						root.setScale(0.285, 0.25);
 						mcdu_canvas_dlg.setColorBackground(0, 0, 0, 1.0);
-						root.createChild("image").set("src", "canvas://by-index/texture[15]");
+						root.createChild("image").set("src", "canvas://by-index/texture[" ~ textureIndex ~ "]");
 					]]>
 				</load>
 				<unload>

--- a/gui/dialogs/mcdu2-dlg.xml
+++ b/gui/dialogs/mcdu2-dlg.xml
@@ -179,11 +179,20 @@
 			<nasal>
 				<load>
 					<![CDATA[
+						var textureIndex = 16;
+						foreach (var texture; props.globals.getNode("/canvas/by-index").getChildren("texture")) {
+							var name = texture.getChild("name");
+							if (name != nil and name.getValue() == "MCDU2") {
+								textureIndex = texture.getIndex();
+								break;
+							}
+						}
+
 						var mcdu_canvas_dlg = canvas.get(cmdarg());
 						var root = mcdu_canvas_dlg.createGroup();
 						root.setScale(0.285, 0.25);
 						mcdu_canvas_dlg.setColorBackground(0, 0, 0, 1.0);
-						root.createChild("image").set("src", "canvas://by-index/texture[16]");
+						root.createChild("image").set("src", "canvas://by-index/texture[" ~ textureIndex ~ "]");
 					]]>
 				</load>
 				<unload>


### PR DESCRIPTION
Instead of giving a hardcoded texture index,  search for them by name.

### Description of Changes
It looks like the add-on, like https://github.com/PlayeRom/flightgear-addon-logbook creates its canvas textures earlier than the aircraft. Then at index 15 and 16 used in MCDUs dialogs, are textures from the add-on and not the expected ones from the aircraft. Therefore, it is best not to rely on hardcoded indexes and just find the right one.

### Screenshots (optional)
Image shows texture loaded from index 16 when add-on is enabled https://github.com/PlayeRom/flightgear-addon-logbook. This is a texture from the add-on, not MCDU2.

![Zaznaczenie_123](https://user-images.githubusercontent.com/3813203/223778141-7718f198-5eba-46f2-b986-b9133fec33da.png)

### Bugs fixed (if any)
n/a

### Checklist:
* [X] My changes follow the Contributing Guidelines.
* [ ] My changes implement realistic features.
* [ ] Please have a main Developer test my changes before merging.
