### PR TITLE
Fix FGCamera keybindings according to the current version

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -2423,8 +2423,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>1</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>0</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2469,8 +2468,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>2</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>1</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2516,8 +2514,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>3</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>2</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2563,8 +2560,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>4</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>3</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2610,8 +2606,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>5</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>4</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2659,8 +2654,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>6</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>5</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2716,8 +2710,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>7</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>6</camera-id>
 				</binding>
 				<binding>
 					<condition>
@@ -2752,8 +2745,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>8</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>7</camera-id>
 				</binding>
 				<!--binding>
 					<condition>
@@ -2799,8 +2791,7 @@
 						<property>/options/system/fgcamera-keys-enabled</property>
 					</condition>
 					<command>fgcamera-select</command>
-					<camera-id>9</camera-id>
-					<camera-type>aircraft</camera-type>
+					<camera-id>8</camera-id>
 				</binding>
 				<!--binding>
 					<condition>

--- a/gui/dialogs/mcdu1-dlg.xml
+++ b/gui/dialogs/mcdu1-dlg.xml
@@ -179,11 +179,20 @@
 			<nasal>
 				<load>
 					<![CDATA[
+						var textureIndex = 15;
+						foreach (var texture; props.globals.getNode("/canvas/by-index").getChildren("texture")) {
+							var name = texture.getChild("name");
+							if (name != nil and name.getValue() == "MCDU1") {
+								textureIndex = texture.getIndex();
+								break;
+							}
+						}
+
 						var mcdu_canvas_dlg = canvas.get(cmdarg());
 						var root = mcdu_canvas_dlg.createGroup();
 						root.setScale(0.285, 0.25);
 						mcdu_canvas_dlg.setColorBackground(0, 0, 0, 1.0);
-						root.createChild("image").set("src", "canvas://by-index/texture[15]");
+						root.createChild("image").set("src", "canvas://by-index/texture[" ~ textureIndex ~ "]");
 					]]>
 				</load>
 				<unload>

--- a/gui/dialogs/mcdu2-dlg.xml
+++ b/gui/dialogs/mcdu2-dlg.xml
@@ -179,11 +179,20 @@
 			<nasal>
 				<load>
 					<![CDATA[
+						var textureIndex = 16;
+						foreach (var texture; props.globals.getNode("/canvas/by-index").getChildren("texture")) {
+							var name = texture.getChild("name");
+							if (name != nil and name.getValue() == "MCDU2") {
+								textureIndex = texture.getIndex();
+								break;
+							}
+						}
+
 						var mcdu_canvas_dlg = canvas.get(cmdarg());
 						var root = mcdu_canvas_dlg.createGroup();
 						root.setScale(0.285, 0.25);
 						mcdu_canvas_dlg.setColorBackground(0, 0, 0, 1.0);
-						root.createChild("image").set("src", "canvas://by-index/texture[16]");
+						root.createChild("image").set("src", "canvas://by-index/texture[" ~ textureIndex ~ "]");
 					]]>
 				</load>
 				<unload>


### PR DESCRIPTION
Fix FGCamera keybindings according to the current version

### Description of Changes
For a human, key 1 is the first camera, but FG Camera numbers the cameras from 0, so the key 1 should switch to camera ID 0, key 2 to camera 1, etc.

### Screenshots (optional)

### Bugs fixed (if any)
n/a

### Checklist:
* [x] My changes follow the Contributing Guidelines.
* [ ] My changes implement realistic features.
* [ ] Please have a main Developer test my changes before merging.
