### PR TITLE
Lights: Mark landing/taxi compositor lights as high priority

### DIFF
--- a/Models/A320-common.xml
+++ b/Models/A320-common.xml
@@ -490,6 +490,7 @@
 	<light>
 		<name>Landing Light Left Compositor</name>
 		<type>spot</type>
+		<priority>high</priority>
 		<position>
 			<x-m>-2.080</x-m>
 			<y-m>-2.22016</y-m>
@@ -531,6 +532,7 @@
 	<light>
 		<name>Landing Light Right Compositor</name>
 		<type>spot</type>
+		<priority>high</priority>
 		<position>
 			<x-m>-2.080</x-m>
 			<y-m> 2.22016</y-m>
@@ -572,6 +574,7 @@
 	<light>
 		<name>Taxi Light Compositor</name>
 		<type>spot</type>
+		<priority>high</priority>
 		<position>
 			<x-m>-13.461</x-m>
 			<y-m>0.20414</y-m>
@@ -613,6 +616,7 @@
 	<light>
 		<name>Left Turnoff Compositor</name>
 		<type>spot</type>
+		<priority>medium</priority>
 		<position>
 			<x-m>-13.5034</x-m>
 			<y-m>-0.20993</y-m>
@@ -654,6 +658,7 @@
 	<light>
 		<name>Right Turnoff Compositor</name>
 		<type>spot</type>
+		<priority>medium</priority>
 		<position>
 			<x-m>-13.5034</x-m>
 			<y-m> 0.20914</y-m>
@@ -695,6 +700,7 @@
 	<light>
 		<name>Nose Landing Light Compositor</name>
 		<type>spot</type>
+		<priority>high</priority>
 		<position>
 			<x-m>-13.5119</x-m>
 			<y-m>-0.185175</y-m>


### PR DESCRIPTION
### Description of Changes
For compositor lights, add priority hints so that if compositor can't render all lights, it will choose the most important ones first (landing/taxi/turnoff).

### Bugs fixed (if any)
When the number of compositor light cones is limited, some 'eyecandy' lights (beacon/nav/strobe, for which illuminating the ground is not important) were rendered at the expense of the actually important lights (landing/taxi/turnoff).

### Checklist:
* [x] My changes follow the Contributing Guidelines.
* [ ] My changes implement realistic features.
* [ ] Please have a main Developer test my changes before merging.