### PR TITLE
Acc thr red correction as tested

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -711,6 +711,7 @@
 					<cmd type="double">0</cmd>
 				</athr>
 				<clbreduc-ft type="double">1500</clbreduc-ft>
+				<ga-clbreduc-ft type="double">1500</ga-clbreduc-ft>
 				<control-1 n="0">
 					<detent-text type="string">IDLE</detent-text>
 					<n1-mode-sw type="bool">0</n1-mode-sw>

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -4408,12 +4408,31 @@ var canvas_MCDU_base = {
 					me["Simple_C5"].setFontSize(normal); 
 					me["Simple_C5"].setText(sprintf("/%4.0f           ", accelAltFt.getValue()));
 				} else {
-					me["Simple_L5"].setColor(WHITE);
-					me["Simple_L5"].setFontSize(small); 
-					me["Simple_L5"].setText("-----");
-					me["Simple_C5"].setColor(WHITE);
-					me["Simple_C5"].setFontSize(small); 
-					me["Simple_C5"].setText(sprintf("/-----                ", accelAltFt.getValue()));
+					if (thrRedSetManual.getBoolValue()){
+						me["Simple_L5"].setFontSize(normal); 
+						me["Simple_L5"].setText(sprintf("%4.0f", clbReducFt.getValue()));
+						if (accSetManual.getBoolValue()) {
+							me["Simple_C5"].setFontSize(normal); 
+							me["Simple_C5"].setText(sprintf("/%4.0f           ", accelAltFt.getValue()));
+						} else {
+							me["Simple_C5"].setColor(WHITE);
+							me["Simple_C5"].setFontSize(small); 
+							me["Simple_C5"].setText(sprintf("/-----               ", accelAltFt.getValue()));
+						}
+					} else {
+						me["Simple_L5"].setColor(WHITE);
+						me["Simple_L5"].setFontSize(small); 
+						me["Simple_L5"].setText("-----");
+						if (accSetManual.getBoolValue()) {
+							me["Simple_C5"].setColor(BLUE);
+							me["Simple_C5"].setFontSize(normal); 
+							me["Simple_C5"].setText(sprintf("/%4.0f            ", accelAltFt.getValue()));
+						} else {
+							me["Simple_C5"].setColor(WHITE);
+							me["Simple_C5"].setFontSize(small); 
+							me["Simple_C5"].setText(sprintf("/-----                ", accelAltFt.getValue()));
+						}
+					}
 				}
 			} else {
 				if (thrRedSetManual.getBoolValue()){

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5142,18 +5142,19 @@ var canvas_MCDU_base = {
 			
 			if(fmgc.FMGCInternal.arrApt == ""){
 				if(ga_thrRedSetManual.getBoolValue()) {
-					# should be in normal font
+					me["Simple_L5"].setFontSize(normal);
 					me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
 				} else { 
+					me["Simple_L5"].setFontSize(small);
 					me["Simple_L5"].setText("-----");
 				}
 
 				if(ga_accSetManual.getBoolValue()){
-						# should be in normal font
-						me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
+						me["Simple_C5"].setFontSize(normal);
+						me["Simple_C5"].setText(sprintf("/%4.0f               ", ga_accelAltFt.getValue()));
 				} else {
 					# should be in small font
-					me["Simple_C5"].setText(sprintf("/-----                "));
+					me["Simple_C5"].setText(sprintf("/-----              "));
 				}
 			} else {
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -92,6 +92,8 @@ var altitude = props.globals.getNode("/instrumentation/altimeter/indicated-altit
 var clbReducFt = props.globals.getNode("/fdm/jsbsim/fadec/clbreduc-ft", 1);
 var accelAltFt = props.globals.getNode("/FMGC/internal/accel-agl-ft", 1); # It's not AGL anymore
 var thrAccSet = props.globals.getNode("/MCDUC/thracc-set", 1);
+var accSetManual = props.globals.getNode("/MCDUC/acc-set-manual", 1);
+var thrRedSetManual = props.globals.getNode("/MCDUC/thrRed-set-manual", 1);
 var flex = props.globals.getNode("/fdm/jsbsim/fadec/limit/flex-temp", 1);
 var flexSet = props.globals.getNode("/fdm/jsbsim/fadec/limit/flex-active-cmd", 1);
 var engOutAcc = props.globals.getNode("/FMGC/internal/eng-out-reduc", 1);
@@ -4393,20 +4395,32 @@ var canvas_MCDU_base = {
 				me["Simple_L3"].hide();
 			}
 			
-			if (thrAccSet.getValue() == 1) {
-				me["Simple_L5"].setFontSize(normal);
+			if(fmgc.FMGCInternal.depApt == ""){
+				# todo: as for now FMGC will use default thrRed/accelAlt values unless it is overwritten
+				# these default values are not displayed in MCDU
+
+				if (accSetManual.getBoolValue() and thrRedSetManual.getBoolValue()){
+					me["Simple_L5"].setColor(BLUE);
+					me["Simple_L5"].setFontSize(normal); 
+					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));					
+				} else {
+					me["Simple_L5"].setColor(WHITE);
+					me["Simple_L5"].setFontSize(small); 
+					me["Simple_L5"].setText("-----/-----");
+				}
 			} else {
-				me["Simple_L5"].setFontSize(small);
-			}
-			
-			if(fmgc.accelAltValid){
-				me["Simple_L5"].setColor(BLUE);
-				me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));
-			} else {
-				# MCDU will show dashes if thrustRed and accelAlt is not initialized
-				# as for now FMGC will use default value unless it is overwritten
-				me["Simple_L5"].setColor(WHITE);
-				me["Simple_L5"].setText("-----/-----");
+				# todo: split font size if just one value set manulally
+				# for now both set to normal if one is set 
+
+				if (accSetManual.getBoolValue() or thrRedSetManual.getBoolValue()){
+					me["Simple_L5"].setColor(BLUE);
+					me["Simple_L5"].setFontSize(normal); 
+					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));
+				} else {
+					me["Simple_L5"].setColor(BLUE);
+					me["Simple_L5"].setFontSize(small); 
+					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));				
+				}
 			}
 
 			if (fmgc.FMGCInternal.toFlapThsSet) {
@@ -6160,3 +6174,4 @@ setlistener("/MCDU[0]/page", func {
 setlistener("/MCDU[1]/page", func {
 	pageSwitch[1].setBoolValue(0);
 }, 0, 0);
+

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -4421,7 +4421,7 @@ var canvas_MCDU_base = {
 						} else {
 							me["Simple_C5"].setColor(WHITE);
 							me["Simple_C5"].setFontSize(small); 
-							me["Simple_C5"].setText(sprintf("/-----               ", accelAltFt.getValue()));
+							me["Simple_C5"].setText(sprintf("/-----               "));
 						}
 					} else {
 						me["Simple_L5"].setColor(WHITE);
@@ -4434,7 +4434,7 @@ var canvas_MCDU_base = {
 						} else {
 							me["Simple_C5"].setColor(WHITE);
 							me["Simple_C5"].setFontSize(small); 
-							me["Simple_C5"].setText(sprintf("/-----                ", accelAltFt.getValue()));
+							me["Simple_C5"].setText(sprintf("/-----                "));
 						}
 					}
 				}
@@ -5106,7 +5106,7 @@ var canvas_MCDU_base = {
 				showRight(me,-1, -1, -1, -1, 1, -1);
 				showRightS(me,-1, -1, -1, -1, 1, -1);
 				showRightArrow(me,-1, -1, -1, -1, -1, -1);
-				showCenter(me,1, 1, 1, -1, -1, -1);
+				showCenter(me,1, 1, 1, -1, 1, -1);
 				me["Simple_C3B"].hide();
 				me["Simple_C4B"].hide();
 				showCenterS(me,1, 1, 1, -1, -1, -1);
@@ -5133,19 +5133,26 @@ var canvas_MCDU_base = {
 			} else {
 				me["Simple_Title"].setColor(WHITE);
 			}
-			
-			if (ga_thrRedSetManual.getValue() == 1) {
-				me["Simple_L5"].setFontSize(normal);
-			} else {
-				me["Simple_L5"].setFontSize(small);
-			}
+
 			if (engOutAccSet.getValue() == 1) {
 				me["Simple_R5"].setFontSize(normal);
 			} else {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
-			if(fmgc.FMGCInternal.arrApt == nil){
+			if(fmgc.FMGCInternal.arrApt == ""){
+				if (ga_thrRedSetManual.getBoolValue()) {
+					#me["Simple_L5"].setFontSize(normal); 
+					me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
+				} else {
+					me["Simple_L5"].setText("-----");
+#					if (ga_accSetManual.getBoolValue()) {
+						me["Simple_C5"].setText(sprintf("/%4.0f            ", ga_accelAltFt.getValue()));
+#					} else {
+#						me["Simple_C5"].setText(sprintf("/-----                "));
+#					}
+				}
+			} else {
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
 				if (ga_accSetManual.getBoolValue()) {
 					me["Simple_C5"].setFontSize(normal); 
@@ -5154,7 +5161,6 @@ var canvas_MCDU_base = {
 					me["Simple_C5"].setFontSize(small); 
 					me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
 				}
-				me["Simple_C5"].show();
 			}
 
 			me["Simple_L6"].setText(" PHASE");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5111,10 +5111,10 @@ var canvas_MCDU_base = {
 				me["Simple_C4B"].hide();
 				showCenterS(me,1, 1, 1, -1, -1, -1);
 				
-				me.fontSizeLeft(normal, normal, normal, normal, small, normal);
-				me.fontSizeRight(normal, small, 0, 0, 0, normal);
-				me.fontSizeCenter(small, small, small, 0, small, 0);
-				me.fontSizeCenterS(small, small, small, 0, small, 0);
+				#me.fontSizeLeft(normal, normal, normal, normal, small, normal);
+				#me.fontSizeRight(normal, small, 0, 0, 0, normal);
+				#me.fontSizeCenter(small, small, small, 0, small, 0);
+				#me.fontSizeCenterS(small, small, small, 0, small, 0);
 				
 				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
 				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
@@ -5151,13 +5151,15 @@ var canvas_MCDU_base = {
 
 				if(ga_accSetManual.getBoolValue()){
 						me["Simple_C5"].setFontSize(normal);
-						me["Simple_C5"].setText(sprintf("/%4.0f               ", ga_accelAltFt.getValue()));
+						me["Simple_C5"].setText(sprintf("/%4.0f           ", ga_accelAltFt.getValue()));
 				} else {
-					# should be in small font
+					me["Simple_C5"].setFontSize(small);
 					me["Simple_C5"].setText(sprintf("/-----              "));
 				}
 			} else {
+				me["Simple_L5"].setFontSize(small);
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
+				me["Simple_C5"].setFontSize(small);
 				me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
 			}
 

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5140,9 +5140,6 @@ var canvas_MCDU_base = {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
-			print("ga-acc : " ~ ga_accSetManual.getBoolValue() ~ "," ~ ga_accelAltFt.getValue() ~ 
-				", ga-thrRed " ~ ga_thrRedSetManual.getBoolValue() ~ "," ~ ga_clbReducFt.getValue());
-
 			if(fmgc.FMGCInternal.arrApt == ""){
 				if(ga_accSetManual.getBoolValue())
 				{

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5111,7 +5111,7 @@ var canvas_MCDU_base = {
 				me["Simple_C4B"].hide();
 				showCenterS(me,1, 1, 1, -1, -1, -1);
 				
-				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
+				me.fontSizeLeft(normal, normal, normal, normal, small, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);
 				me.fontSizeCenter(small, small, small, 0, small, 0);
 				me.fontSizeCenterS(small, small, small, 0, small, 0);
@@ -5140,28 +5140,23 @@ var canvas_MCDU_base = {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
+			print("ga-acc : " ~ ga_accSetManual.getBoolValue() ~ "," ~ ga_accelAltFt.getValue() ~ 
+				", ga-thrRed " ~ ga_thrRedSetManual.getBoolValue() ~ "," ~ ga_clbReducFt.getValue());
+
 			if(fmgc.FMGCInternal.arrApt == ""){
-				if (ga_thrRedSetManual.getBoolValue()) {
-					#me["Simple_L5"].setFontSize(normal); 
+				if(ga_accSetManual.getBoolValue())
+				{
 					me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
+					me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
 				} else {
 					me["Simple_L5"].setText("-----");
-#					if (ga_accSetManual.getBoolValue()) {
-						me["Simple_C5"].setText(sprintf("/%4.0f            ", ga_accelAltFt.getValue()));
-#					} else {
-#						me["Simple_C5"].setText(sprintf("/-----                "));
-#					}
+					me["Simple_C5"].setText(sprintf("/-----                "));
 				}
 			} else {
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
-				if (ga_accSetManual.getBoolValue()) {
-					me["Simple_C5"].setFontSize(normal); 
-					me["Simple_C5"].setText(sprintf("/%4.0f            ", ga_accelAltFt.getValue()));
-				} else {
-					me["Simple_C5"].setFontSize(small); 
-					me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
-				}
+				me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
 			}
+
 
 			me["Simple_L6"].setText(" PHASE");
 			me["Simple_L5S"].setText("THR RED/ACC");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5141,19 +5141,25 @@ var canvas_MCDU_base = {
 			}
 			
 			if(fmgc.FMGCInternal.arrApt == ""){
-				if(ga_accSetManual.getBoolValue())
-				{
+				if(ga_thrRedSetManual.getBoolValue()) {
+					# should be in normal font
 					me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
-					me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
-				} else {
+
+					if(ga_accSetManual.getBoolValue()){
+							# should be in normal font
+							me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
+
+					} else {
+						# should be in small font
+						me["Simple_C5"].setText(sprintf("/-----                "));
+					}
+				} else { 
 					me["Simple_L5"].setText("-----");
-					me["Simple_C5"].setText(sprintf("/-----                "));
 				}
 			} else {
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
 				me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
 			}
-
 
 			me["Simple_L6"].setText(" PHASE");
 			me["Simple_L5S"].setText("THR RED/ACC");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -4301,7 +4301,7 @@ var canvas_MCDU_base = {
 				showCenter(me,1, 1, 1, -1, 1, -1);
 				me["Simple_C3B"].hide();
 				me["Simple_C4B"].hide();
-				showCenterS(me,1, 1, 1, -1, 1, -1);
+				showCenterS(me,1, 1, 1, -1, -1, -1);
 				
 				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -4294,15 +4294,15 @@ var canvas_MCDU_base = {
 				showRight(me,-1, 1, 1, 1, 1, 1);
 				showRightS(me,1, 1, 1, 1, 1, 1);
 				showRightArrow(me,-1, -1, -1, -1, -1, 1);
-				showCenter(me,1, 1, 1, -1, -1, -1);
+				showCenter(me,1, 1, 1, -1, 1, -1);
 				me["Simple_C3B"].hide();
 				me["Simple_C4B"].hide();
-				showCenterS(me,1, 1, 1, -1, -1, -1);
+				showCenterS(me,1, 1, 1, -1, 1, -1);
 				
 				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);
-				me.fontSizeCenter(small, small, small, 0, 0, 0);
-				me.fontSizeCenterS(small, small, small, small, small, small);
+				me.fontSizeCenter(small, small, small, 0, small, 0);
+				me.fontSizeCenterS(small, small, small, small, 0, small);
 				
 				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
 				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
@@ -4310,7 +4310,7 @@ var canvas_MCDU_base = {
 				me.colorRight("grn", "blu", "blu", "blu", "blu", "wht");
 				me.colorRightS("wht", "wht", "wht", "wht", "wht", "wht");
 				me.colorRightArrow("wht", "wht", "wht", "wht", "wht", "wht");
-				me.colorCenter("grn", "grn", "grn", "wht", "wht", "wht");
+				me.colorCenter("grn", "grn", "grn", "wht", "blu", "wht");
 				me.colorCenterS("wht", "wht", "wht", "wht", "wht", "wht");
 				me["Simple_Title"].setText("TAKE OFF");
 				
@@ -4353,6 +4353,7 @@ var canvas_MCDU_base = {
 			if (fmgc.FMGCInternal.phase == 1) {  # GREEN title and not modifiable on TO phase
 				me["Simple_Title"].setColor(GREEN);
 				me.colorLeft("grn", "grn", "grn", "blu", "grn", "wht");
+				me.colorCenter("grn", "grn", "grn", "blu", "grn", "wht");
 				me.colorRight("grn", "blu", "grn", "grn", "grn", "wht");
 			} else {				
 				me["Simple_Title"].setColor(WHITE);
@@ -4402,24 +4403,39 @@ var canvas_MCDU_base = {
 				if (accSetManual.getBoolValue() and thrRedSetManual.getBoolValue()){
 					me["Simple_L5"].setColor(BLUE);
 					me["Simple_L5"].setFontSize(normal); 
-					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));					
+					me["Simple_L5"].setText(sprintf("%4.0f", clbReducFt.getValue()));					
+					me["Simple_C5"].setColor(BLUE);
+					me["Simple_C5"].setFontSize(normal); 
+					me["Simple_C5"].setText(sprintf("/%4.0f           ", accelAltFt.getValue()));
 				} else {
 					me["Simple_L5"].setColor(WHITE);
 					me["Simple_L5"].setFontSize(small); 
-					me["Simple_L5"].setText("-----/-----");
+					me["Simple_L5"].setText("-----");
+					me["Simple_C5"].setColor(WHITE);
+					me["Simple_C5"].setFontSize(small); 
+					me["Simple_C5"].setText(sprintf("/-----                ", accelAltFt.getValue()));
 				}
 			} else {
-				# todo: split font size if just one value set manulally
-				# for now both set to normal if one is set 
-
-				if (accSetManual.getBoolValue() or thrRedSetManual.getBoolValue()){
-					me["Simple_L5"].setColor(BLUE);
+				if (thrRedSetManual.getBoolValue()){
 					me["Simple_L5"].setFontSize(normal); 
-					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));
+					me["Simple_L5"].setText(sprintf("%4.0f", clbReducFt.getValue()));
+					if (accSetManual.getBoolValue()) {
+						me["Simple_C5"].setFontSize(normal); 
+						me["Simple_C5"].setText(sprintf("/%4.0f           ", accelAltFt.getValue()));
+					} else {
+						me["Simple_C5"].setFontSize(small); 
+						me["Simple_C5"].setText(sprintf("/%4.0f               ", accelAltFt.getValue()));
+					}
 				} else {
-					me["Simple_L5"].setColor(BLUE);
 					me["Simple_L5"].setFontSize(small); 
-					me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));				
+					me["Simple_L5"].setText(sprintf("%4.0f", clbReducFt.getValue()));
+					if (accSetManual.getBoolValue()) {
+						me["Simple_C5"].setFontSize(normal); 
+						me["Simple_C5"].setText(sprintf("/%4.0f            ", accelAltFt.getValue()));
+					} else {
+						me["Simple_C5"].setFontSize(small); 
+						me["Simple_C5"].setText(sprintf("/%4.0f                 ", accelAltFt.getValue()));
+					}
 				}
 			}
 

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5113,7 +5113,8 @@ var canvas_MCDU_base = {
 				
 				me.fontSizeLeft(normal, normal, normal, normal, 0, normal);
 				me.fontSizeRight(normal, small, 0, 0, 0, normal);
-				me.fontSizeCenter(small, small, small, 0, 0, 0);
+				me.fontSizeCenter(small, small, small, 0, small, 0);
+				me.fontSizeCenterS(small, small, small, 0, small, 0);
 				
 				me.colorLeft("blu", "blu", "blu", "blu", "blu", "wht");
 				me.colorLeftS("wht", "wht", "wht", "wht", "wht", "wht");
@@ -5121,8 +5122,8 @@ var canvas_MCDU_base = {
 				me.colorRight("wht", "blu", "blu", "blu", "blu", "wht");
 				me.colorRightS("wht", "wht", "wht", "wht", "wht", "wht");
 				me.colorRightArrow("wht", "wht", "wht", "wht", "wht", "wht");
-				me.colorCenter("grn", "grn", "grn", "wht", "wht", "wht");
-				me.colorCenterS("wht", "wht", "wht", "wht", "wht", "wht");
+				me.colorCenter("grn", "grn", "grn", "wht", "blu", "wht");
+				me.colorCenterS("wht", "wht", "wht", "wht", "blu", "wht");
 				
 				pageSwitch[i].setBoolValue(1);
 			}
@@ -5144,7 +5145,18 @@ var canvas_MCDU_base = {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
-			me["Simple_L5"].setText(sprintf("%3.0f", ga_clbReducFt.getValue()) ~ sprintf("/%3.0f", ga_accelAltFt.getValue()));
+			if(fmgc.FMGCInternal.arrApt == nil){
+				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
+				if (ga_accSetManual.getBoolValue()) {
+					me["Simple_C5"].setFontSize(normal); 
+					me["Simple_C5"].setText(sprintf("/%4.0f            ", ga_accelAltFt.getValue()));
+				} else {
+					me["Simple_C5"].setFontSize(small); 
+					me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
+				}
+				me["Simple_C5"].show();
+			}
+
 			me["Simple_L6"].setText(" PHASE");
 			me["Simple_L5S"].setText("THR RED/ACC");
 			me["Simple_L6S"].setText(" PREV");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -90,7 +90,7 @@ var state2 = props.globals.getNode("/engines/engine[1]/state", 1);
 var altitude = props.globals.getNode("/instrumentation/altimeter/indicated-altitude-ft", 1);
 # TO PERF
 var clbReducFt = props.globals.getNode("/fdm/jsbsim/fadec/clbreduc-ft", 1);
-var reducFt = props.globals.getNode("/FMGC/internal/accel-agl-ft", 1); # It's not AGL anymore
+var accelAltFt = props.globals.getNode("/FMGC/internal/accel-agl-ft", 1); # It's not AGL anymore
 var thrAccSet = props.globals.getNode("/MCDUC/thracc-set", 1);
 var flex = props.globals.getNode("/fdm/jsbsim/fadec/limit/flex-temp", 1);
 var flexSet = props.globals.getNode("/fdm/jsbsim/fadec/limit/flex-active-cmd", 1);
@@ -4316,7 +4316,6 @@ var canvas_MCDU_base = {
 			}
 			
 			me["Simple_L4"].setText(sprintf("%3.0f", fmgc.FMGCInternal.transAlt));
-			me["Simple_L5"].setText(" " ~ sprintf("%3.0f", clbReducFt.getValue()) ~ sprintf("/%3.0f", reducFt.getValue()));
 			me["Simple_L6"].setText(" TO DATA");
 			me["Simple_L1S"].setText(" V1");
 			me["Simple_L2S"].setText(" VR");
@@ -4400,6 +4399,14 @@ var canvas_MCDU_base = {
 				me["Simple_L5"].setFontSize(small);
 			}
 			
+			if(accelAltFt.getValue() == ""){
+				me["Simple_L5"].setColor(WHITE);
+				me["Simple_L5"].setText("-----/-----");
+			} else {
+				me["Simple_L5"].setColor(BLUE);
+				me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));
+			}
+
 			if (fmgc.FMGCInternal.toFlapThsSet) {
 				me["Simple_R3"].setFontSize(normal);
 				if (fmgc.FMGCInternal.toThs) {
@@ -5082,7 +5089,7 @@ var canvas_MCDU_base = {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
-			me["Simple_L5"].setText(sprintf("%3.0f", clbReducFt.getValue()) ~ sprintf("/%3.0f", reducFt.getValue()));
+			me["Simple_L5"].setText(sprintf("%3.0f", clbReducFt.getValue()) ~ sprintf("/%3.0f", accelAltFt.getValue()));
 			me["Simple_L6"].setText(" PHASE");
 			me["Simple_L5S"].setText("THR RED/ACC");
 			me["Simple_L6S"].setText(" PREV");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -5144,17 +5144,16 @@ var canvas_MCDU_base = {
 				if(ga_thrRedSetManual.getBoolValue()) {
 					# should be in normal font
 					me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));
-
-					if(ga_accSetManual.getBoolValue()){
-							# should be in normal font
-							me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
-
-					} else {
-						# should be in small font
-						me["Simple_C5"].setText(sprintf("/-----                "));
-					}
 				} else { 
 					me["Simple_L5"].setText("-----");
+				}
+
+				if(ga_accSetManual.getBoolValue()){
+						# should be in normal font
+						me["Simple_C5"].setText(sprintf("/%4.0f                 ", ga_accelAltFt.getValue()));
+				} else {
+					# should be in small font
+					me["Simple_C5"].setText(sprintf("/-----                "));
 				}
 			} else {
 				me["Simple_L5"].setText(sprintf("%4.0f", ga_clbReducFt.getValue()));

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -90,7 +90,7 @@ var state2 = props.globals.getNode("/engines/engine[1]/state", 1);
 var altitude = props.globals.getNode("/instrumentation/altimeter/indicated-altitude-ft", 1);
 # TO PERF
 var clbReducFt = props.globals.getNode("/fdm/jsbsim/fadec/clbreduc-ft", 1);
-var accelAltFt = props.globals.getNode("/FMGC/internal/accel-agl-ft", 1); # It's not AGL anymore
+var accelAltFt = props.globals.getNode("/FMGC/internal/accel-agl-ft", 1);
 var thrAccSet = props.globals.getNode("/MCDUC/thracc-set", 1);
 var accSetManual = props.globals.getNode("/MCDUC/acc-set-manual", 1);
 var thrRedSetManual = props.globals.getNode("/MCDUC/thrRed-set-manual", 1);
@@ -111,6 +111,10 @@ var final = props.globals.getNode("/FMGC/internal/final", 1);
 var radio = props.globals.getNode("/FMGC/internal/radio", 1);
 var baro = props.globals.getNode("/FMGC/internal/baro", 1);
 # GA PERF
+var ga_clbReducFt = props.globals.getNode("/fdm/jsbsim/fadec/ga-clbreduc-ft", 1); # differs from TO clbRedcFt
+var ga_accelAltFt = props.globals.getNode("/FMGC/internal/ga-accel-agl-ft", 1); # differs from TO accelAltFt
+var ga_accSetManual = props.globals.getNode("/MCDUC/ga-acc-set-manual", 1);
+var ga_thrRedSetManual = props.globals.getNode("/MCDUC/ga-thrRed-set-manual", 1);
 # AOC - SENSORS
 var gear0_wow = props.globals.getNode("/gear/gear[0]/wow", 1);
 var doorL1_pos = props.globals.getNode("/sim/model/door-positions/doorl1/position-norm", 1); #FWD door
@@ -5129,7 +5133,7 @@ var canvas_MCDU_base = {
 				me["Simple_Title"].setColor(WHITE);
 			}
 			
-			if (thrAccSet.getValue() == 1) {
+			if (ga_thrRedSetManual.getValue() == 1) {
 				me["Simple_L5"].setFontSize(normal);
 			} else {
 				me["Simple_L5"].setFontSize(small);
@@ -5140,7 +5144,7 @@ var canvas_MCDU_base = {
 				me["Simple_R5"].setFontSize(small);
 			}
 			
-			me["Simple_L5"].setText(sprintf("%3.0f", clbReducFt.getValue()) ~ sprintf("/%3.0f", accelAltFt.getValue()));
+			me["Simple_L5"].setText(sprintf("%3.0f", ga_clbReducFt.getValue()) ~ sprintf("/%3.0f", ga_accelAltFt.getValue()));
 			me["Simple_L6"].setText(" PHASE");
 			me["Simple_L5S"].setText("THR RED/ACC");
 			me["Simple_L6S"].setText(" PREV");

--- a/Models/Instruments/MCDU/MCDU.nas
+++ b/Models/Instruments/MCDU/MCDU.nas
@@ -4399,12 +4399,14 @@ var canvas_MCDU_base = {
 				me["Simple_L5"].setFontSize(small);
 			}
 			
-			if(accelAltFt.getValue() == ""){
-				me["Simple_L5"].setColor(WHITE);
-				me["Simple_L5"].setText("-----/-----");
-			} else {
+			if(fmgc.accelAltValid){
 				me["Simple_L5"].setColor(BLUE);
 				me["Simple_L5"].setText("" ~ sprintf("%4.0f", clbReducFt.getValue()) ~ sprintf("/%4.0f", accelAltFt.getValue()));
+			} else {
+				# MCDU will show dashes if thrustRed and accelAlt is not initialized
+				# as for now FMGC will use default value unless it is overwritten
+				me["Simple_L5"].setColor(WHITE);
+				me["Simple_L5"].setText("-----/-----");
 			}
 
 			if (fmgc.FMGCInternal.toFlapThsSet) {

--- a/Models/Liveries/PW-NEO/DLH.xml
+++ b/Models/Liveries/PW-NEO/DLH.xml
@@ -19,6 +19,7 @@
 		<company-options>
 			<idle-factor>+0.0</idle-factor>
 			<perf-factor>+0.0</perf-factor>
+			<default-thrRed-agl type="int">1000</default-thrRed-agl>
 			<default-accel-agl type="int">1000</default-accel-agl>
 		</company-options>
 		<model-options>

--- a/Models/Liveries/PW-NEO/DLH.xml
+++ b/Models/Liveries/PW-NEO/DLH.xml
@@ -19,6 +19,7 @@
 		<company-options>
 			<idle-factor>+0.0</idle-factor>
 			<perf-factor>+0.0</perf-factor>
+			<default-accel-agl type="int">1000</default-accel-agl>
 		</company-options>
 		<model-options>
 			<registration type="string">D-AINK</registration>

--- a/Models/Liveries/PW-NEO/DLH.xml
+++ b/Models/Liveries/PW-NEO/DLH.xml
@@ -21,6 +21,8 @@
 			<perf-factor>+0.0</perf-factor>
 			<default-thrRed-agl type="int">1000</default-thrRed-agl>
 			<default-accel-agl type="int">1000</default-accel-agl>
+			<default-ga-thrRed-agl type="int">1000</default-ga-thrRed-agl>
+			<default-ga-accel-agl type="int">1000</default-ga-accel-agl>
 		</company-options>
 		<model-options>
 			<registration type="string">D-AINK</registration>

--- a/Models/Liveries/PW-NEO/DLH.xml
+++ b/Models/Liveries/PW-NEO/DLH.xml
@@ -21,8 +21,8 @@
 			<perf-factor>+0.0</perf-factor>
 			<default-thrRed-agl type="int">1000</default-thrRed-agl>
 			<default-accel-agl type="int">1000</default-accel-agl>
-			<default-ga-thrRed-agl type="int">1000</default-ga-thrRed-agl>
-			<default-ga-accel-agl type="int">1000</default-ga-accel-agl>
+			<default-ga-thrRed-agl type="int">1500</default-ga-thrRed-agl>
+			<default-ga-accel-agl type="int">1500</default-ga-accel-agl>
 		</company-options>
 		<model-options>
 			<registration type="string">D-AINK</registration>

--- a/Models/Liveries/PW-NEO/NKS.xml
+++ b/Models/Liveries/PW-NEO/NKS.xml
@@ -19,6 +19,7 @@
 		<company-options>
 			<idle-factor>+0.0</idle-factor>
 			<perf-factor>+0.0</perf-factor>
+			<default-accel-agl type="int">1500</default-accel-agl>
 		</company-options>
 		<model-options>
 			<registration type="string">N903NK</registration>

--- a/Nasal/FMGC/FCU.nas
+++ b/Nasal/FMGC/FCU.nas
@@ -288,6 +288,8 @@ var FCUController = {
 						fmgc.Input.kts.setValue(me.iasTemp);
 					}
 				}
+			} else {
+				# speed preselection on FCU as speed is managed
 			}
 		}
 	},

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -157,6 +157,7 @@ var FMGCInternal = {
 	gndTemp: 15,
 	gndTempSet: 0,
 	depApt: "",
+	depAptElev: 0,
 	tropo: 36090,
 	tropoSet: 0,
 	toFromSet: 0,

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -129,6 +129,10 @@ var FMGCInternal = {
 	toFlap: 0,
 	toThs: 0,
 	toFlapThsSet: 0,
+	accelAlt: 0,
+	accelAltSet: 0,
+	thrRedAlt: 0,
+	thrRedAltSet: 0,
 	
 	# PERF APPR
 	destMag: 0,
@@ -158,7 +162,7 @@ var FMGCInternal = {
 	gndTemp: 15,
 	gndTempSet: 0,
 	depApt: "",
-	depAptElev: nil,
+	depAptElev: 0,
 	tropo: 36090,
 	tropoSet: 0,
 	toFromSet: 0,

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -15,7 +15,6 @@ var gs = 0;
 var state1 = 0;
 var state2 = 0;
 var accel_agl_ft = 0;
-var accelAltValid = 0; # barrier to say it is not initialized
 var fd1 = 0;
 var fd2 = 0;
 var spd = 0;
@@ -35,6 +34,18 @@ var windHdg = 0;
 var windSpeed = 0;
 var windsDidChange = 0;
 var tempOverspeed = nil;
+var pinOptionGaAccelAlt = 1500;
+if (getprop("/options/company-options/default-ga-accel-agl") != nil) {
+	pinOptionGaAccelAlt = getprop("/options/company-options/default-ga-accel-agl");
+}
+var pinOptionGaThrRedAlt = 400;
+if (getprop("/options/company-options/default-ga-thrRed-agl") != nil) {
+	pinOptionGaThrRedAlt = getprop("/options/company-options/default-ga-thrRed-agl");
+}
+# min Value for ThrRed and AccelAlt are the company pin option defaults
+var minAccelAlt = getprop("/options/company-options/default-accel-agl");
+var minThrRed = getprop("/options/company-options/default-thrRed-agl");
+
 
 setprop("/position/gear-agl-ft", 0);
 # 1500 ft is a default value not shown anywhere. It may not exist.

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -667,6 +667,9 @@ var masterFMGC = maketimer(0.2, func {
 			systems.PNEU.pressMode.setValue("TO");
 		}
 	} elsif (FMGCInternal.phase == 2) {
+		# change FADEC thrReduction from T/O-thrRedAlt to G/A-thrRedAlt
+		systems.FADEC.clbReduc = systems.FADEC.gaClbReduc;
+
 		if ((Modes.PFD.FMA.pitchMode == "ALT CRZ" or Modes.PFD.FMA.pitchMode == "ALT CRZ*")) {
 			newphase = 3;
 			systems.PNEU.pressMode.setValue("CR");
@@ -694,7 +697,7 @@ var masterFMGC = maketimer(0.2, func {
 			Input.toga.setValue(1);
 		}
 	} elsif (FMGCInternal.phase == 6) {
-		if (alt >= accel_agl_ft) { # todo when insert altn or new dest
+		if (alt >= getprop("/FMGC/internal/ga-accel-agl-ft")) { # todo when insert altn or new dest
 			newphase = 2;
 		}
 	}

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -46,8 +46,8 @@ if (getprop("/options/company-options/default-ga-thrRed-agl") != nil) {
 var minAccelAlt = getprop("/options/company-options/default-accel-agl");
 var minThrRed = getprop("/options/company-options/default-thrRed-agl");
 
-
 setprop("/position/gear-agl-ft", 0);
+
 # 1500 ft is a default value not shown anywhere. It may not exist.
 # In case it does not exist, a takeoff with no departure airport and no accel set would never go from TO PHASE to CLB PHASE
 # unless manually set.

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -157,6 +157,7 @@ var FMGCInternal = {
 	altAirportSet: 0,
 	altSelected: 0,
 	arrApt: "",
+	destAptElev: 0,
 	coRoute: "",
 	coRouteSet: 0,
 	costIndex: 0,

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -146,6 +146,12 @@ var FMGCInternal = {
 	ldgConfig3: 0,
 	ldgConfigFull: 0,
 	
+	# PERF GA
+	gaAccelAlt: 0,
+	gaAccelAltSet: 0,
+	gaThrRedAlt: 0,
+	gaThrRedAltSet: 0,
+	
 	# INIT A
 	altAirport: "",
 	altAirportSet: 0,

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -157,7 +157,7 @@ var FMGCInternal = {
 	gndTemp: 15,
 	gndTempSet: 0,
 	depApt: "",
-	depAptElev: 0,
+	depAptElev: nil,
 	tropo: 36090,
 	tropoSet: 0,
 	toFromSet: 0,

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -37,7 +37,10 @@ var windsDidChange = 0;
 var tempOverspeed = nil;
 
 setprop("/position/gear-agl-ft", 0);
-setprop("/it-autoflight/settings/accel-ft", 1500); #eventually set to 1500 above runway
+# 1500 ft is a default value not shown anywhere. It may not exist.
+# In case it does not exist, a takeoff with no departure airport and no accel set would never go from TO PHASE to CLB PHASE
+# unless manually set.
+setprop("/it-autoflight/settings/accel-ft", 1500);
 setprop("/it-autoflight/internal/vert-speed-fpm", 0);
 setprop("/instrumentation/nav[0]/nav-id", "XXX");
 setprop("/instrumentation/nav[1]/nav-id", "XXX");

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -15,6 +15,7 @@ var gs = 0;
 var state1 = 0;
 var state2 = 0;
 var accel_agl_ft = 0;
+var accelAltValid = 0; # barrier to say it is not initialized
 var fd1 = 0;
 var fd2 = 0;
 var spd = 0;

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -265,16 +265,24 @@ var initInputA = func(key, i) {
 							fmgc.FMGCNodes.toFromSet.setValue(1);
 							mcdu_scratchpad.scratchpads[i].empty();
 							fmgc.FMGCInternal.depAptElev = math.round(airportinfo(fromto[0]).elevation * M2FT, 10);
-							if (fmgc.FMGCInternal.depAptElev != nil) {
-								var newAccelAlt = fmgc.FMGCInternal.depAptElev;
-								if (getprop("/options/company-options/default-accel-agl")) {
-									newAccelAlt += getprop("/options/company-options/default-accel-agl");
-								} else {
-									newAccelAlt += 400 ; # minimum accel agl if no company option
-								}
+
+							if (getprop("/options/company-options/default-accel-agl")) {
+								fmgc.FMGCInternal.AccelAlt = getprop("/options/company-options/default-accel-agl") + fmgc.FMGCInternal.depAptElev;
+							} else {
+								fmgc.FMGCInternal.AccelAlt = 400 + fmgc.FMGCInternal.depAptElev; # todo: minimum accel agl if no company option
 							}
-							# check FCU alt
-							setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
+
+							if (getprop("/options/company-options/default-thrRed-agl")) {
+								fmgc.FMGCInternal.thrRedAlt = getprop("/options/company-options/default-thrRed-agl") + fmgc.FMGCInternal.depAptElev;
+							} else {
+								fmgc.FMGCInternal.thrRedAlt = 400 + fmgc.FMGCInternal.depAptElev; # todo: minimum thrRed agl if no company option
+							}
+							setprop("/FMGC/internal/accel-agl-ft", fmgc.FMGCInternal.AccelAlt);
+							setprop("/fdm/jsbsim/fadec/clbreduc-ft", fmgc.FMGCInternal.thrRedAlt);
+							setprop("MCDUC/thracc-set", 0);
+							setprop("MCDUC/acc-set-manual", 0);
+							setprop("MCDUC/thrRed-set-manual", 0);
+
 							fmgc.flightPlanController.updateAirports(fromto[0], fromto[1], 2);
 							fmgc.FMGCInternal.altSelected = 0;
 							fmgc.updateARPT();

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -265,7 +265,16 @@ var initInputA = func(key, i) {
 							fmgc.FMGCNodes.toFromSet.setValue(1);
 							mcdu_scratchpad.scratchpads[i].empty();
 							fmgc.FMGCInternal.depAptElev = math.round(airportinfo(fromto[0]).elevation * M2FT, 10);
-							setprop("/FMGC/internal/accel-agl-ft", fmgc.FMGCInternal.depAptElev);
+							if (fmgc.FMGCInternal.depAptElev != nil) {
+								var newAccelAlt = fmgc.FMGCInternal.depAptElev;
+								if (getprop("/options/company-options/default-accel-agl")) {
+									newAccelAlt += getprop("/options/company-options/default-accel-agl");
+								} else {
+									newAccelAlt += 400 ; # minimum accel agl if no company option
+								}
+							}
+							# check FCU alt
+							setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
 							fmgc.flightPlanController.updateAirports(fromto[0], fromto[1], 2);
 							fmgc.FMGCInternal.altSelected = 0;
 							fmgc.updateARPT();

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -7,8 +7,19 @@ var resetFlightplan = func(i) {
 	fmgc.FMGCInternal.depApt = "";
 	fmgc.FMGCInternal.arrApt = "";
 	fmgc.FMGCInternal.toFromSet = 0;
+	fmgc.FMGCInternal.depAptElev = 0;
 	fmgc.FMGCNodes.toFromSet.setValue(0);
 	fmgc.windController.resetDesWinds();
+
+	# clbreduc-ft and accel-agl-ft are set to arbitrary values they may not exist.
+	# In case they do not exist, a takeoff with no departure airport and no accel set would never go from TO PHASE to CLB PHASE
+	# unless manually changed.
+	setprop("/FMGC/internal/accel-agl-ft", 1500);
+	setprop("/fdm/jsbsim/fadec/clbreduc-ft", 1500);
+	setprop("MCDUC/thracc-set", 0);
+	setprop("MCDUC/acc-set-manual", 0);
+	setprop("MCDUC/thrRed-set-manual", 0);
+
 	setprop("/FMGC/internal/align-ref-lat", 0);
 	setprop("/FMGC/internal/align-ref-long", 0);
 	setprop("/FMGC/internal/align-ref-lat-edit", 0);

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -264,11 +264,8 @@ var initInputA = func(key, i) {
 							fmgc.FMGCInternal.toFromSet = 1;
 							fmgc.FMGCNodes.toFromSet.setValue(1);
 							mcdu_scratchpad.scratchpads[i].empty();
-
 							fmgc.FMGCInternal.depAptElev = math.round(airportinfo(fromto[0]).elevation * M2FT, 10);
-							print ("Fra Elevation " , fmgc.FMGCInternal.depAptElev);
-
-							
+							setprop("/FMGC/internal/accel-agl-ft", fmgc.FMGCInternal.depAptElev);
 							fmgc.flightPlanController.updateAirports(fromto[0], fromto[1], 2);
 							fmgc.FMGCInternal.altSelected = 0;
 							fmgc.updateARPT();

--- a/Nasal/MCDU/INITA.nas
+++ b/Nasal/MCDU/INITA.nas
@@ -264,6 +264,10 @@ var initInputA = func(key, i) {
 							fmgc.FMGCInternal.toFromSet = 1;
 							fmgc.FMGCNodes.toFromSet.setValue(1);
 							mcdu_scratchpad.scratchpads[i].empty();
+
+							fmgc.FMGCInternal.depAptElev = math.round(airportinfo(fromto[0]).elevation * M2FT, 10);
+							print ("Fra Elevation " , fmgc.FMGCInternal.depAptElev);
+
 							
 							fmgc.flightPlanController.updateAirports(fromto[0], fromto[1], 2);
 							fmgc.FMGCInternal.altSelected = 0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -153,7 +153,6 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.vrset = 0;
 	fmgc.FMGCInternal.v2 = 0;
 	fmgc.FMGCInternal.v2set = 0;
-	print("Default accel ", getprop("/options/default-accel-agl"));
 	setprop("/FMGC/internal/accel-agl-ft", 1500); #eventually set to 1500 above runway
 	setprop("/MCDUC/thracc-set", 0);
 	fmgc.FMGCInternal.toFlap = 0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -196,7 +196,7 @@ var MCDU_reset = func(i) {
 	setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", 1500);
 	setprop("/FMGC/internal/ga-accel-agl-ft", 1500);
 	setprop("MCDUC/ga-acc-set-manual", 0);
-	setprop("MCDUC/ga-thracc-set", 0);
+	setprop("MCDUC/ga-thrRed-set-manual", 0);
 }
 
 var setMode = func(will) {

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -153,6 +153,7 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.vrset = 0;
 	fmgc.FMGCInternal.v2 = 0;
 	fmgc.FMGCInternal.v2set = 0;
+	print("Default accel ", getprop("/options/default-accel-agl"));
 	setprop("/FMGC/internal/accel-agl-ft", 1500); #eventually set to 1500 above runway
 	setprop("/MCDUC/thracc-set", 0);
 	fmgc.FMGCInternal.toFlap = 0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -154,7 +154,7 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.v2 = 0;
 	fmgc.FMGCInternal.v2set = 0;
 	print("Default accel ", getprop("/options/default-accel-agl"));
-	setprop("/FMGC/internal/accel-agl-ft", ""); #eventually set to 1500 above runway
+	setprop("/FMGC/internal/accel-agl-ft", 1500); #eventually set to 1500 above runway
 	setprop("/MCDUC/thracc-set", 0);
 	fmgc.FMGCInternal.toFlap = 0;
 	fmgc.FMGCInternal.toThs = 0.0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -154,7 +154,7 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.v2 = 0;
 	fmgc.FMGCInternal.v2set = 0;
 	print("Default accel ", getprop("/options/default-accel-agl"));
-	setprop("/FMGC/internal/accel-agl-ft", 1500); #eventually set to 1500 above runway
+	setprop("/FMGC/internal/accel-agl-ft", ""); #eventually set to 1500 above runway
 	setprop("/MCDUC/thracc-set", 0);
 	fmgc.FMGCInternal.toFlap = 0;
 	fmgc.FMGCInternal.toThs = 0.0;

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -154,7 +154,10 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.v2 = 0;
 	fmgc.FMGCInternal.v2set = 0;
 	setprop("/FMGC/internal/accel-agl-ft", 1500); #eventually set to 1500 above runway
-	setprop("/MCDUC/thracc-set", 0);
+	setprop("/fdm/jsbsim/fadec/clbreduc-ft", 1500);
+	setprop("MCDUC/thracc-set", 0);
+	setprop("MCDUC/acc-set-manual", 0);
+	setprop("MCDUC/thrRed-set-manual", 0);
 	fmgc.FMGCInternal.toFlap = 0;
 	fmgc.FMGCInternal.toThs = 0.0;
 	fmgc.FMGCInternal.toFlapThsSet = 0;
@@ -190,6 +193,10 @@ var MCDU_reset = func(i) {
 	fmgc.FMGCInternal.ldgConfigFull = 1;
 	
 	# GA PERF
+	setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", 1500);
+	setprop("/FMGC/internal/ga-accel-agl-ft", 1500);
+	setprop("MCDUC/ga-acc-set-manual", 0);
+	setprop("MCDUC/ga-thracc-set", 0);
 }
 
 var setMode = func(will) {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -6,12 +6,21 @@ var perfGAInput = func(key, i) {
 	var scratchpad = mcdu_scratchpad.scratchpads[i].scratchpad;
 	if (key == "L5") {
 		if (scratchpad == "CLR") {
-			setprop("/fdm/jsbsim/fadec/clbreduc-ft", 1500);
-			setprop("/FMGC/internal/accel-agl-ft", 1500);
-			setprop("MCDUC/thracc-set", 0);
+			if (fmgc.FMGCInternal.arrApt != "") {
+				fmgc.FMGCInternal.gaThrRedAlt = fmgc.pinOptionGaThrRedAlt + fmgc.FMGCInternal.destAptElev;
+				fmgc.FMGCInternal.gaAccelAlt = fmgc.pinOptionGaAccelAlt + fmgc.FMGCInternal.destAptElev;
+			} else {
+				fmgc.FMGCInternal.gathrRedAlt = fmgc.pinOptionGaThrRedAlt;
+				fmgc.FMGCInternal.gaAccelAlt = fmgc.pinOptionGaAccelAlt;
+			}
+
+			setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", fmgc.FMGCInternal.gaThrRedAlt);
+			setprop("/FMGC/internal/ga-accel-agl-ft", fmgc.FMGCInternal.gaAccelAlt);
 			setprop("MCDUC/ga-acc-set-manual", 0);
-			setprop("MCDUC/ga-thracc-set", 0);
+			setprop("MCDUC/ga-thrRed-set-manual", 0);
+
 			mcdu_scratchpad.scratchpads[i].empty();
+
 		} else {
 			var tfs = size(scratchpad);
 			if (tfs >= 7 and tfs <= 9 and find("/", scratchpad) != -1) {
@@ -21,7 +30,13 @@ var perfGAInput = func(key, i) {
 				if (int(thrred) != nil and int(acc) != nil and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)) {
 					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", thracc[0]);
 					setprop("/FMGC/internal/ga-accel-agl-ft", thracc[1]);
-					setprop("MCDUC/thracc-set", 1);
+#					setprop("MCDUC/thracc-set", 1);
+					setprop("MCDUC/ga-acc-set-manual", 1);
+					setprop("MCDUC/ga-thrRed-set-manual", 1);
+					mcdu_scratchpad.scratchpads[i].empty();
+				} else if (int(thrred) == nil and int(acc) != nil and (acc >= 3 and acc <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
+					setprop("/FMGC/internal/ga-accel-agl-ft", int(acc / 10) * 10);
+					setprop("MCDUC/ga-acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "NOT ALLOWED");

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -1,7 +1,5 @@
 # Copyright (c) 2020 Matthew Maring (mattmaring)
 
-# and flinkekoralle 2023
-
 # uses universal values, will implement separately once FPLN is finished
 
 var perfGAInput = func(key, i) {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -1,5 +1,7 @@
 # Copyright (c) 2020 Matthew Maring (mattmaring)
 
+# and flinkekoralle 2023
+
 # uses universal values, will implement separately once FPLN is finished
 
 var perfGAInput = func(key, i) {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -9,6 +9,8 @@ var perfGAInput = func(key, i) {
 			setprop("/fdm/jsbsim/fadec/clbreduc-ft", 1500);
 			setprop("/FMGC/internal/accel-agl-ft", 1500);
 			setprop("MCDUC/thracc-set", 0);
+			setprop("MCDUC/ga-acc-set-manual", 0);
+			setprop("MCDUC/ga-thracc-set", 0);
 			mcdu_scratchpad.scratchpads[i].empty();
 		} else {
 			var tfs = size(scratchpad);
@@ -17,8 +19,8 @@ var perfGAInput = func(key, i) {
 				var thrred = size(thracc[0]);
 				var acc = size(thracc[1]);
 				if (int(thrred) != nil and int(acc) != nil and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)) {
-					setprop("/fdm/jsbsim/fadec/clbreduc-ft", thracc[0]);
-					setprop("/FMGC/internal/accel-agl-ft", thracc[1]);
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", thracc[0]);
+					setprop("/FMGC/internal/ga-accel-agl-ft", thracc[1]);
 					setprop("MCDUC/thracc-set", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -23,10 +23,12 @@ var perfGAInput = func(key, i) {
 
 		} else {
 			var tfs = size(scratchpad);
-			if (tfs >= 7 and tfs <= 9 and find("/", scratchpad) != -1) {
+			print("Scr:" ~ scratchpad);
+			if (find("/", scratchpad) != -1) {
 				var thracc = split("/", scratchpad);
 				var thrred = size(thracc[0]);
 				var acc = size(thracc[1]);
+				print("red " ~ thracc[0] ~ "," ~ thrred ~ " acc " ~ thracc[1] ~ "," ~ acc ~ " tfs " ~ tfs);
 				if (int(thrred) != nil and int(acc) != nil and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)) {
 					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", thracc[0]);
 					setprop("/FMGC/internal/ga-accel-agl-ft", thracc[1]);
@@ -34,13 +36,29 @@ var perfGAInput = func(key, i) {
 					setprop("MCDUC/ga-acc-set-manual", 1);
 					setprop("MCDUC/ga-thrRed-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
-				} else if (int(thrred) == nil and int(acc) != nil and (acc >= 3 and acc <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
-					setprop("/FMGC/internal/ga-accel-agl-ft", int(acc / 10) * 10);
-					setprop("MCDUC/ga-acc-set-manual", 1);
-					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
-					mcdu_message(i, "NOT ALLOWED");
+					if (int(thrred) == 0 and int(acc) != nil 
+						and (acc >= 3 and acc <= 5) 
+						and thracc[1] >= 1500 and thracc[1] <= 39000) {
+						setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
+						setprop("MCDUC/ga-acc-set-manual", 1);
+						mcdu_scratchpad.scratchpads[i].empty();
+					}
+					if (int(thrred) != nil and int(acc) == nil 
+						and thracc[0] >= 400 and thracc[0] <= 39000
+						and (thrred >= 3 and thrred <= 5)) {
+						setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
+						setprop("MCDUC/ga-thrRed-set-manual", 1);
+						mcdu_scratchpad.scratchpads[i].empty();
+					} else {
+						mcdu_message(i, "NOT ALLOWED");
+					}
 				}
+			} else if ((num(scratchpad) != nil) and (tfs >= 3 and tfs <= 5) 
+				and (scratchpad >= 400) and (scratchpad <= 39000)) {
+				setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(scratchpad / 10) * 10);
+				setprop("MCDUC/ga-thrRed-set-manual", 1);
+				mcdu_scratchpad.scratchpads[i].empty();
 			} else {
 				mcdu_message(i, "NOT ALLOWED");
 			}

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -36,6 +36,8 @@ var perfGAInput = func(key, i) {
 					tempAcc = tempThrRed; # accel is always greater or eqal thrust reduction
 				}
 
+				# at the moment 400ft/1500ft and 39000ft are hard coded defaults.
+				# needs to be checked
 				if (tempThrRed >= 400 and tempThrRed <= 39000 and tempAcc >= 1500 and tempAcc <= 39000) {
 					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", tempThrRed);
 					setprop("/FMGC/internal/ga-accel-agl-ft", tempAcc);

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -27,38 +27,50 @@ var perfGAInput = func(key, i) {
 				var thracc = split("/", scratchpad);
 				var thrred = size(thracc[0]);
 				var acc = size(thracc[1]);
-				if (thracc[0] > thracc[1]) {
-					thracc[1] = thracc[0]; # accel is always greater or eqal thrust reduction
+				var tempThrRed = 0;
+				var tempAcc = 0;
+				if (thrred >= 3 and thrred <= 5) {tempThrRed = int(thracc[0]/ 10) * 10;}
+				if (acc >= 3 and acc <= 5) {tempAcc = int(thracc[1]/ 10) * 10;}
+
+				if (thrred and acc and tempAcc < tempThrRed) {
+					tempAcc = tempThrRed; # accel is always greater or eqal thrust reduction
 				}
-				if (int(thrred) != nil and int(acc) != nil 
-				and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)
-				and thracc[0] >= 400 and thracc[0] <= 39000 and thracc[1] >= 1500 and thracc[1] <= 39000) {
-					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
-					setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
+
+				if (tempThrRed >= 400 and tempThrRed <= 39000 and tempAcc >= 1500 and tempAcc <= 39000) {
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", tempThrRed);
+					setprop("/FMGC/internal/ga-accel-agl-ft", tempAcc);
 					setprop("MCDUC/ga-acc-set-manual", 1);
 					setprop("MCDUC/ga-thrRed-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
-				} else if (int(thrred) == 0 and int(acc) != nil and (acc >= 3 and acc <= 5) and thracc[1] >= 1500 and thracc[1] <= 39000) {
-					setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
+				} else if (tempAcc >= 1500 and tempAcc <= 39000) {
+					setprop("/FMGC/internal/ga-accel-agl-ft", tempAcc);
 					setprop("MCDUC/ga-acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
-				} else if (int(thrred) != nil and int(acc) == nil and thracc[0] >= 400 and thracc[0] <= 39000 and (thrred >= 3 and thrred <= 5)) {
-					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
+				} else if (tempThrRed >= 400 and tempThrRed <= 39000) {
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", tempThrRed);
 					setprop("MCDUC/ga-thrRed-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "NOT ALLOWED");
 				}
-			} else if ((num(scratchpad) != nil) and (tfs >= 3 and tfs <= 5) and (scratchpad >= 400) and (scratchpad <= 39000)) {
-				if (scratchpad > getprop("/FMGC/internal/ga-accel-agl-ft")){
-					setprop("/FMGC/internal/ga-accel-agl-ft", scratchpad); # set accel as high as thrRed
-				} else {
-					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(scratchpad / 10) * 10);
-				}
-				setprop("MCDUC/ga-thrRed-set-manual", 1);
-				mcdu_scratchpad.scratchpads[i].empty();
 			} else {
-				mcdu_message(i, "NOT ALLOWED");
+				if (tfs >= 3 and tfs <= 5){
+					var tempImp = int(scratchpad / 10) * 10;
+					if (tempImp and (tempImp >= 400) and (tempImp <= 39000)) {
+						setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", tempImp);
+						setprop("MCDUC/ga-thrRed-set-manual", 1);
+
+						if (tempImp > getprop("/FMGC/internal/ga-accel-agl-ft")){ # set accel as high as thrRed
+							setprop("/FMGC/internal/ga-accel-agl-ft", tempImp);
+							setprop("MCDUC/ga-acc-set-manual", 1);
+						}
+						mcdu_scratchpad.scratchpads[i].empty();
+					} else {
+						mcdu_message(i, "NOT ALLOWED");
+					}
+				} else {
+					mcdu_message(i, "NOT ALLOWED");
+				}
 			}
 		}
 	} else if (key == "L6") {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -10,7 +10,7 @@ var perfGAInput = func(key, i) {
 				fmgc.FMGCInternal.gaThrRedAlt = fmgc.pinOptionGaThrRedAlt + fmgc.FMGCInternal.destAptElev;
 				fmgc.FMGCInternal.gaAccelAlt = fmgc.pinOptionGaAccelAlt + fmgc.FMGCInternal.destAptElev;
 			} else {
-				fmgc.FMGCInternal.gathrRedAlt = fmgc.pinOptionGaThrRedAlt;
+				fmgc.FMGCInternal.gaThrRedAlt = fmgc.pinOptionGaThrRedAlt;
 				fmgc.FMGCInternal.gaAccelAlt = fmgc.pinOptionGaAccelAlt;
 			}
 
@@ -23,40 +23,38 @@ var perfGAInput = func(key, i) {
 
 		} else {
 			var tfs = size(scratchpad);
-			print("Scr:" ~ scratchpad);
 			if (find("/", scratchpad) != -1) {
 				var thracc = split("/", scratchpad);
 				var thrred = size(thracc[0]);
 				var acc = size(thracc[1]);
-				print("red " ~ thracc[0] ~ "," ~ thrred ~ " acc " ~ thracc[1] ~ "," ~ acc ~ " tfs " ~ tfs);
-				if (int(thrred) != nil and int(acc) != nil and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)) {
+				if (thracc[0] > thracc[1]) {
+					thracc[1] = thracc[0]; # accel is always greater or eqal thrust reduction
+				}
+				if (int(thrred) != nil and int(acc) != nil 
+				and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)
+				and thracc[0] >= 400 and thracc[0] <= 39000 and thracc[1] >= 1500 and thracc[1] <= 39000) {
 					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", thracc[0]);
 					setprop("/FMGC/internal/ga-accel-agl-ft", thracc[1]);
-#					setprop("MCDUC/thracc-set", 1);
 					setprop("MCDUC/ga-acc-set-manual", 1);
 					setprop("MCDUC/ga-thrRed-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
+				} else if (int(thrred) == 0 and int(acc) != nil and (acc >= 3 and acc <= 5) and thracc[1] >= 1500 and thracc[1] <= 39000) {
+					setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
+					setprop("MCDUC/ga-acc-set-manual", 1);
+					mcdu_scratchpad.scratchpads[i].empty();
+				} else if (int(thrred) != nil and int(acc) == nil and thracc[0] >= 400 and thracc[0] <= 39000 and (thrred >= 3 and thrred <= 5)) {
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
+					setprop("MCDUC/ga-thrRed-set-manual", 1);
+					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
-					if (int(thrred) == 0 and int(acc) != nil 
-						and (acc >= 3 and acc <= 5) 
-						and thracc[1] >= 1500 and thracc[1] <= 39000) {
-						setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
-						setprop("MCDUC/ga-acc-set-manual", 1);
-						mcdu_scratchpad.scratchpads[i].empty();
-					}
-					if (int(thrred) != nil and int(acc) == nil 
-						and thracc[0] >= 400 and thracc[0] <= 39000
-						and (thrred >= 3 and thrred <= 5)) {
-						setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
-						setprop("MCDUC/ga-thrRed-set-manual", 1);
-						mcdu_scratchpad.scratchpads[i].empty();
-					} else {
-						mcdu_message(i, "NOT ALLOWED");
-					}
+					mcdu_message(i, "NOT ALLOWED");
 				}
-			} else if ((num(scratchpad) != nil) and (tfs >= 3 and tfs <= 5) 
-				and (scratchpad >= 400) and (scratchpad <= 39000)) {
-				setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(scratchpad / 10) * 10);
+			} else if ((num(scratchpad) != nil) and (tfs >= 3 and tfs <= 5) and (scratchpad >= 400) and (scratchpad <= 39000)) {
+				if (scratchpad > getprop("/FMGC/internal/ga-accel-agl-ft")){
+					setprop("/FMGC/internal/ga-accel-agl-ft", scratchpad); # set accel as high as thrRed
+				} else {
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(scratchpad / 10) * 10);
+				}
 				setprop("MCDUC/ga-thrRed-set-manual", 1);
 				mcdu_scratchpad.scratchpads[i].empty();
 			} else {

--- a/Nasal/MCDU/PERFGA.nas
+++ b/Nasal/MCDU/PERFGA.nas
@@ -33,8 +33,8 @@ var perfGAInput = func(key, i) {
 				if (int(thrred) != nil and int(acc) != nil 
 				and (thrred >= 3 and thrred <= 5) and (acc >= 3 and acc <= 5)
 				and thracc[0] >= 400 and thracc[0] <= 39000 and thracc[1] >= 1500 and thracc[1] <= 39000) {
-					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", thracc[0]);
-					setprop("/FMGC/internal/ga-accel-agl-ft", thracc[1]);
+					setprop("/fdm/jsbsim/fadec/ga-clbreduc-ft", int(thracc[0] / 10) * 10);
+					setprop("/FMGC/internal/ga-accel-agl-ft", int(thracc[1] / 10) * 10);
 					setprop("MCDUC/ga-acc-set-manual", 1);
 					setprop("MCDUC/ga-thrRed-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -184,7 +184,7 @@ var perfTOInput = func(key, i) {
 				var accs = size(acc);
 
 				#TODO - manual check - four digit alwway 0000 - default = runaway_elevation + 800 ft, min values runaway_elevation+400ft
-				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
+				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= fmgc.minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
 						setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(thrred / 10) * 10);
 						setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 						setprop("MCDUC/thracc-set", 1);

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -150,7 +150,18 @@ var perfTOInput = func(key, i) {
 	} else if (key == "L5" and modifiable) {
 		if (scratchpad == "CLR") {
 			setprop("/fdm/jsbsim/fadec/clbreduc-ft", 1500);
-			setprop("/FMGC/internal/accel-agl-ft", 1500);
+			if (fmgc.FMGCInternal.depAptElev != nil) {
+				var newAccelAlt = fmgc.FMGCInternal.depAptElev;
+				if (getprop("/options/company-options/default-accel-agl")) {
+					newAccelAlt += getprop("/options/company-options/default-accel-agl");
+				} else {
+					newAccelAlt += 400; # minimum accel agl if no company option
+				}
+				setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
+				print("Default livery ", getprop("/options/company-options/default-accel-agl"))
+			} else {
+				setprop("/FMGC/internal/accel-agl-ft", 2500); # dep elev = 0, set default
+			}
 			setprop("MCDUC/thracc-set", 0);
 			mcdu_scratchpad.scratchpads[i].empty();
 		} else {

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -188,25 +188,20 @@ var perfTOInput = func(key, i) {
 
 				#TODO - manual check - four digit alwway 0000 - default = runaway_elevation + 800 ft, min values runaway_elevation+400ft
 				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
-
-					# if (thrred<=acc) { # validation
 						setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(thrred / 10) * 10);
 						setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 						setprop("MCDUC/thracc-set", 1);
 						setprop("MCDUC/acc-set-manual", 1);
 						setprop("MCDUC/thrRed-set-manual", 1);
 						mcdu_scratchpad.scratchpads[i].empty();
-					#} else {
-					#	mcdu_message(i, "NOT ALLOWED");	
-					#}
-				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000 and fmgc.FMGCInternal.depAptElev > 0) {
+				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
 					setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 					setprop("MCDUC/acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "FORMAT ERROR");
 				}
-			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000 and fmgc.FMGCInternal.depAptElev > 0) {
+			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000) {
 				setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(scratchpad / 10) * 10);
 				setprop("MCDUC/thrRed-set-manual", 1);
 				mcdu_scratchpad.scratchpads[i].empty();

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -176,11 +176,6 @@ var perfTOInput = func(key, i) {
 			mcdu_scratchpad.scratchpads[i].empty();
 		} else {
 			var tfs = size(scratchpad);
-
-			# min Value for ThrRed and AccelAlt are the company defaults
-			var minAccelAlt = getprop("/options/company-options/default-accel-agl");
-			var minThrRed = getprop("/options/company-options/default-thrRed-agl");
-
 			if (find("/", scratchpad) != -1) {
 				var thracc = split("/", scratchpad);
 				var thrred = thracc[0];
@@ -189,21 +184,21 @@ var perfTOInput = func(key, i) {
 				var accs = size(acc);
 
 				#TODO - manual check - four digit alwway 0000 - default = runaway_elevation + 800 ft, min values runaway_elevation+400ft
-				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
+				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
 						setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(thrred / 10) * 10);
 						setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 						setprop("MCDUC/thracc-set", 1);
 						setprop("MCDUC/acc-set-manual", 1);
 						setprop("MCDUC/thrRed-set-manual", 1);
 						mcdu_scratchpad.scratchpads[i].empty();
-				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
+				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= fmgc.minAccelAlt and acc <= 39000) {
 					setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 					setprop("MCDUC/acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "FORMAT ERROR");
 				}
-			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000) {
+			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= fmgc.minThrRed and scratchpad <= 39000) {
 				setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(scratchpad / 10) * 10);
 				setprop("MCDUC/thrRed-set-manual", 1);
 				mcdu_scratchpad.scratchpads[i].empty();

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -189,29 +189,29 @@ var perfTOInput = func(key, i) {
 				#TODO - manual check - four digit alwway 0000 - default = runaway_elevation + 800 ft, min values runaway_elevation+400ft
 				if (int(thrred) != nil and (thrreds >= 3 and thrreds <= 5) and thrred >= minThrRed and thrred <= 39000 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
 
-					if (thrred<=acc) { # validation
+					# if (thrred<=acc) { # validation
 						setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(thrred / 10) * 10);
 						setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 						setprop("MCDUC/thracc-set", 1);
 						setprop("MCDUC/acc-set-manual", 1);
 						setprop("MCDUC/thrRed-set-manual", 1);
 						mcdu_scratchpad.scratchpads[i].empty();
-					} else {
-						mcdu_message(i, "NOT ALLOWED");	
-					}
+					#} else {
+					#	mcdu_message(i, "NOT ALLOWED");	
+					#}
 				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
 					setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 					setprop("MCDUC/acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
-					mcdu_message(i, "NOT ALLOWED");
+					mcdu_message(i, "FORMAT ERROR");
 				}
 			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000) {
 				setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(scratchpad / 10) * 10);
 				setprop("MCDUC/thrRed-set-manual", 1);
 				mcdu_scratchpad.scratchpads[i].empty();
 			} else {
-				mcdu_message(i, "NOT ALLOWED");
+				mcdu_message(i, "FORMAT ERROR");
 			}
 		}
 	} else if (key == "R3" and modifiable) {

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -199,14 +199,14 @@ var perfTOInput = func(key, i) {
 					#} else {
 					#	mcdu_message(i, "NOT ALLOWED");	
 					#}
-				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000) {
+				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= minAccelAlt and acc <= 39000 and fmgc.FMGCInternal.depAptElev > 0) {
 					setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 					setprop("MCDUC/acc-set-manual", 1);
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "FORMAT ERROR");
 				}
-			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000) {
+			} else if (num(scratchpad) != nil and (tfs >= 3 and tfs <= 5) and scratchpad >= minThrRed and scratchpad <= 39000 and fmgc.FMGCInternal.depAptElev > 0) {
 				setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(scratchpad / 10) * 10);
 				setprop("MCDUC/thrRed-set-manual", 1);
 				mcdu_scratchpad.scratchpads[i].empty();

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -162,8 +162,8 @@ var perfTOInput = func(key, i) {
 					fmgc.FMGCInternal.thrRedAlt = 400 + fmgc.FMGCInternal.depAptElev; # todo: minimum thrRed agl if no company option
 				}
 			} else {
-				fmgc.FMGCInternal.AccelAlt = 1500; # todo: default accel if no depApt
-				fmgc.FMGCInternal.thrRedAlt = 1500; # todo: ThrRed accel if no depApt
+				fmgc.FMGCInternal.AccelAlt = 1500; # todo: default accel if no depApt / probably doesn't exist?
+				fmgc.FMGCInternal.thrRedAlt = 1500; # todo: default ThrRed if no depApt / probably doesn't exist?
 			}
 			setprop("/FMGC/internal/accel-agl-ft", fmgc.FMGCInternal.AccelAlt);
 			setprop("/fdm/jsbsim/fadec/clbreduc-ft", fmgc.FMGCInternal.thrRedAlt);

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -159,8 +159,6 @@ var perfTOInput = func(key, i) {
 				}
 				setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
 				print("Default livery ", getprop("/options/company-options/default-accel-agl"))
-			} else {
-				setprop("/FMGC/internal/accel-agl-ft", 2500); # dep elev = 0, set default
 			}
 			setprop("MCDUC/thracc-set", 0);
 			mcdu_scratchpad.scratchpads[i].empty();

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -153,13 +153,15 @@ var perfTOInput = func(key, i) {
 				if (getprop("/options/company-options/default-accel-agl")) {
 					fmgc.FMGCInternal.AccelAlt = getprop("/options/company-options/default-accel-agl") + fmgc.FMGCInternal.depAptElev;
 				} else {
-					fmgc.FMGCInternal.AccelAlt = 400 + fmgc.FMGCInternal.depAptElev; # todo: minimum accel agl if no company option
+					# to check: minimum value if no company option is 400 ft above dep aerodrome
+					fmgc.FMGCInternal.AccelAlt = 400 + fmgc.FMGCInternal.depAptElev;
 				}
 
 				if (getprop("/options/company-options/default-thrRed-agl")) {
 					fmgc.FMGCInternal.thrRedAlt = getprop("/options/company-options/default-thrRed-agl") + fmgc.FMGCInternal.depAptElev;
 				} else {
-					fmgc.FMGCInternal.thrRedAlt = 400 + fmgc.FMGCInternal.depAptElev; # todo: minimum thrRed agl if no company option
+					# to check: minimum value if no company option is 400 ft above dep aerodrome
+					fmgc.FMGCInternal.thrRedAlt = 400 + fmgc.FMGCInternal.depAptElev;
 				}
 			} else {
 				fmgc.FMGCInternal.AccelAlt = 1500; # todo: default accel if no depApt / probably doesn't exist?

--- a/Nasal/MCDU/PERFTO.nas
+++ b/Nasal/MCDU/PERFTO.nas
@@ -158,6 +158,7 @@ var perfTOInput = func(key, i) {
 					newAccelAlt += 400; # minimum accel agl if no company option
 				}
 				setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
+				fmgc.accelAltValid = 1;
 				print("Default livery ", getprop("/options/company-options/default-accel-agl"))
 			}
 			setprop("MCDUC/thracc-set", 0);
@@ -179,12 +180,14 @@ var perfTOInput = func(key, i) {
 						setprop("/fdm/jsbsim/fadec/clbreduc-ft", int(thrred / 10) * 10);
 						setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
 						setprop("MCDUC/thracc-set", 1);
+						fmgc.accelAltValid = 1;
 						mcdu_scratchpad.scratchpads[i].empty();
 					} else {
 						mcdu_message(i, "NOT ALLOWED");	
 					}
 				} else if (thrreds == 0 and int(acc) != nil and (accs >= 3 and accs <= 5) and acc >= 400 and acc <= 39000) {
 					setprop("/FMGC/internal/accel-agl-ft", int(acc / 10) * 10);
+					fmgc.accelAltValid = 1;
 					mcdu_scratchpad.scratchpads[i].empty();
 				} else {
 					mcdu_message(i, "NOT ALLOWED");
@@ -335,4 +338,25 @@ var perfTOInput = func(key, i) {
 	} else {
 		mcdu_message(i, "NOT ALLOWED");
 	}
+}
+
+var setAccelAlt = func(newAccelAlt) {
+	var tmpAccelAlt = 800;
+	if (fmgc.FMGCInternal.depAptElev != nil) {
+		tmpAccelAlt = fmgc.FMGCInternal.depAptElev;
+		if (getprop("/options/company-options/default-accel-agl")) {
+			tmpAccelAlt += getprop("/options/company-options/default-accel-agl");
+		} else {
+			tmpAccelAlt += 400; # minimum accel agl if no company option
+		}
+	}
+	if (newAccelAlt >= tmpAccelAlt) {
+		if (newAccelAlt <= mcdu.clbReducFt) {
+			newAccelAlt = mcdu.clbReducFt;
+		}
+	} else {
+		newAccelAlt = tmpAccelAlt;
+	}
+	setprop("/FMGC/internal/accel-agl-ft", newAccelAlt);
+	fmgc.accelAltValid = 1;
 }

--- a/Nasal/Systems/fadec-common.nas
+++ b/Nasal/Systems/fadec-common.nas
@@ -11,6 +11,7 @@ var FADEC = {
 	alphaFloor: props.globals.getNode("/fdm/jsbsim/fadec/alpha-floor"),
 	alphaFloorSwitch: props.globals.getNode("/fdm/jsbsim/fadec/alpha-floor-switch"),
 	clbReduc: props.globals.getNode("/fdm/jsbsim/fadec/clbreduc-ft"),
+	gaClbReduc: props.globals.getNode("/fdm/jsbsim/fadec/ga-clbreduc-ft"),
 	detent: [props.globals.getNode("/fdm/jsbsim/fadec/control-1/detent", 1), props.globals.getNode("/fdm/jsbsim/fadec/control-2/detent", 1)],
 	detentTemp: [0, 0],
 	detentText: [props.globals.getNode("/fdm/jsbsim/fadec/control-1/detent-text"), props.globals.getNode("/fdm/jsbsim/fadec/control-2/detent-text")],

--- a/Systems/fmgc-drivers.xml
+++ b/Systems/fmgc-drivers.xml
@@ -935,6 +935,51 @@
 		</input>
 		<output>/it-autoflight/settings/accel-ft</output>
 	</filter>
+
+	<filter>
+		<name>GA Accel Altitude</name>
+		<type>gain</type>
+		<gain>1.0</gain>
+		<input>
+			<condition>
+				<or>
+					<and>
+						<equals>
+							<property>/engines/engine[0]/state</property>
+							<value>3</value>
+						</equals>
+						<not>
+							<equals>
+								<property>/engines/engine[1]/state</property>
+								<value>3</value>
+							</equals>
+						</not>
+					</and>
+					<and>
+						<not>
+							<equals>
+								<property>/engines/engine[0]/state</property>
+								<value>3</value>
+							</equals>
+						</not>
+						<equals>
+							<property>/engines/engine[1]/state</property>
+							<value>3</value>
+						</equals>
+					</and>
+				</or>
+			</condition>
+			<expression>
+				<property>/FMGC/internal/ga-eng-out-reduc</property>
+			</expression>
+		</input>
+		<input>
+			<expression>
+				<property>/FMGC/internal/ga-accel-agl-ft</property>
+			</expression>
+		</input>
+		<output>/it-autoflight/settings/ga-accel-ft</output>
+	</filter>
 	
 	<!-- Flight Director -->
 	<filter>


### PR DESCRIPTION
<!-- short description -->
acceleration altitude and thrust reduction input on PERF-TO corrected

### Description of Changes
<!--  detailed description -->
Once departure airport is chosen, the default company accel/thrRed is set.
The minimum value that can be inserted (manual entry) is the company default.
The company default value can be inserted in the specific livery aircraft.
E.g. DLH is 1000/1000 agl.
To Do:
The acceleration altitude is inserted in the Simple_C5 line of the mcdu.
A better solution would be to implement a split line for split entries on left and right side of mcdu.
### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [ ] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
