### PR TITLE
Display 'REFUELG' memo on upper ECAM only when the Fuel Truck is connected. When it is enabled but disconneced, hide the 'REFUELG' memo.

### DIFF
--- a/Nasal/ECAM/ECAM-logic.nas
+++ b/Nasal/ECAM/ECAM-logic.nas
@@ -3757,7 +3757,7 @@ var messages_config_memo = func {
 
 var messages_memo = func {
 	phaseVarMemo2 = pts.ECAM.fwcWarningPhase.getValue();
-	if (getprop("/services/fuel-truck/enable") == 1 and toMemoLine1.active != 1 and ldgMemoLine1.active != 1) {
+	if (getprop("/services/fuel-truck/connect") == 1 and toMemoLine1.active != 1 and ldgMemoLine1.active != 1) {
 		refuelg.active = 1;
 	} else {
 		refuelg.active = 0;


### PR DESCRIPTION
### Description of Changes
Change "/services/fuel-truck/enable" to "/services/fuel-truck/connect" as condition to show the 'REFUELG' memo on the ECAM.

### Screenshots (optional)
![fgfs-20240910110005](https://github.com/user-attachments/assets/809fea43-8599-47b5-b5da-fc75dd71c6cf)
![fgfs-20240910110012](https://github.com/user-attachments/assets/78cc468e-9a49-46cb-83ce-44238b69a3ee)
![fgfs-20240910110017](https://github.com/user-attachments/assets/13449175-f3af-48a2-85d5-10a29c452846)



### Bugs fixed (if any)
Fixes #338 

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [X] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [X] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
