### PR TITLE
Fix cockpit APU and emer light indicator logic

### DIFF
--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -27992,7 +27992,7 @@
 		<type>select</type>
 		<object-name>APUMasterBtn2O</object-name>
 		<condition>
-			<property>/controls/indicators/apu-master-fault</property>
+			<property>/controls/indicators/apu-master-on</property>
 		</condition>
 	</animation>
 

--- a/Systems/a320-indicators.xml
+++ b/Systems/a320-indicators.xml
@@ -556,7 +556,7 @@
 			<default value="0"/>
 			<test logic="AND" value="1">
 				<test logic="OR" value="1">
-					/controls/switches/emer-lights ne 1
+					/controls/switches/emer-lights eq 0
 					/controls/switches/annun-test eq 1
 				</test>
 				<test logic="OR" value="1">


### PR DESCRIPTION
Fixes minor logical issues in the A320 cockpit

These are small corrections to preserve expected cockpit indications and animations.

### Description of Changes
- In `Models/FlightDeck/a320.flightdeck.xml`, corrected a duplicated animation condition for `APUMasterBtn2O`, changing the reference from `apu-master-fault` to the correct `apu-master-on` property.
- In `Systems/a320-indicators.xml`, fixed the emergency exit indicator logic to properly reflect the `/controls/switches/emer-lights` state by using `eq 0` instead of `ne 1`, restoring the intended behavior after previous refactoring.

### Bugs fixed (if any)
- Wrong condition logic for the APU master button, which could lead to a missing indication.
- Incorrect logical test on the `emer-lights` switch, potentially displaying the wrong indicator status.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x ] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

Tested locally with FG 2024.1 and confirmed the emer indicator and APU button operate as expected.

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
