### PR TITLE
Add CG %MAC computation (clamped 0–100)

### DIFF
--- a/Systems/a320-fcs.xml
+++ b/Systems/a320-fcs.xml
@@ -4,95 +4,132 @@
 <!-- Copyright (c) 2025 Josh Davidson (Octal450) -->
 
 <system name="A320: FCS">
-	
+
 	<property value="0">/controls/flight/flaps-input-last</property>
-	
+
+	<!--  CG %MAC computation  -->
+	<channel name="CG Percent MAC">
+		<!-- Output: /fdm/jsbsim/inertia/cg-percent-mac -->
+		<fcs_function name="inertia/cg-percent-mac">
+			<function>
+				<product>
+					<quotient>
+						<difference>
+							<!-- Convert CG X from inches (FG) to meters -->
+							<product>
+								<property>inertia/cg-x-in</property>
+								<value>0.0254</value>
+								<!-- in → m -->
+							</product>
+
+							<!-- LEMAC position in meters -->
+							<value>-3.508</value>
+						</difference>
+
+						<!-- MAC length in meters -->
+						<value>4.193</value>
+					</quotient>
+
+					<!-- Convert ratio to percent -->
+					<value>100</value>
+				</product>
+			</function>
+
+			<!-- Clamp output so it never goes outside 0–100% -->
+			<clipto>
+				<min>0</min>
+				<max>100</max>
+			</clipto>
+		</fcs_function>
+	</channel>
+
 	<channel name="Surface Droop">
-		
+
 		<fcs_function name="/systems/fcs/aileron-droop">
 			<function>
 				<table>
 					<independentVar lookup="row">aero/qbar-psf</independentVar>
 					<tableData>
-						 7  1
-						31  0
+						7 1
+						31 0
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/aileron-droop-rate">
 			<function>
 				<table>
 					<independentVar lookup="row">aero/qbar-psf</independentVar>
 					<tableData>
-						 7  0.333333
-						31  2
+						7 0.333333
+						31 2
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/elevator-droop">
 			<function>
 				<table>
 					<independentVar lookup="row">aero/qbar-psf</independentVar>
 					<tableData>
-						 8  1
-						32  0
+						8 1
+						32 0
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/elevator-droop-rate">
 			<function>
 				<table>
 					<independentVar lookup="row">aero/qbar-psf</independentVar>
 					<tableData>
-						 8  0.333333
-						32  2
+						8 0.333333
+						32 2
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/rudder-swing">
 			<function>
 				<table>
-					<independentVar lookup="row">/velocities/airspeed-kt</independentVar> <!-- rudder is rather large at 7m2... so it doesn't take much speed to stop it -->
+					<independentVar lookup="row">/velocities/airspeed-kt</independentVar> <!-- rudder
+					is rather large at 7m2... so it doesn't take much speed to stop it -->
 					<tableData>
-						 12  1.0
-						 35  0.0
+						12 1.0
+						35 0.0
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<actuator name="spoilers/anti-droop-cmd">
 			<input>/systems/fbw/spoiler-output</input>
 			<rate_limit sense="incr">0.9</rate_limit>
 			<rate_limit sense="decr">2.5</rate_limit>
 		</actuator>
-		
+
 		<fcs_function name="spoilers/anti-droop-final">
 			<function>
 				<table>
 					<independentVar lookup="row">spoilers/anti-droop-cmd</independentVar>
 					<tableData>
-						0.5  0.0
-						1.0  1.0
+						0.5 0.0
+						1.0 1.0
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-	
+
 	</channel>
-	
+
 	<channel name="Aileron Logic">
-		
+
 		<switch name="/systems/fcs/aileron-l/pressure-switch-or">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				<test logic="AND">
 					/systems/fctl/elac1 eq 1
@@ -104,17 +141,17 @@
 				</test>
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/aileron-l/actuator-enabled">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1">
 				/systems/fcs/aileron-l/pressure-switch-or eq 1
 				/systems/failures/aileron-left eq 0
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/aileron-r/pressure-switch-or">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				<test logic="AND">
 					/systems/fctl/elac1 eq 1
@@ -126,19 +163,19 @@
 				</test>
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/aileron-r/actuator-enabled">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1">
 				/systems/fcs/aileron-r/pressure-switch-or eq 1
 				/systems/failures/aileron-right eq 0
 			</test>
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Aileron L">
-		
+
 		<summer name="/systems/fcs/aileron-l/input">
 			<input>/systems/fbw/aileron-output</input>
 			<input>-/systems/fbw/laf/output-ail</input>
@@ -147,7 +184,7 @@
 				<max>1.0</max>
 			</clipto>
 		</summer>
-		
+
 		<fcs_function name="/systems/fcs/aileron-l/extended">
 			<function>
 				<sum>
@@ -156,7 +193,7 @@
 				</sum>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/aileron-l/retracted">
 			<function>
 				<sum>
@@ -167,17 +204,17 @@
 						<table>
 							<independentVar lookup="row">/fdm/jsbsim/fcs/flap-pos-deg</independentVar>
 							<tableData>
-								1  0.00
-								5  0.26
+								1 0.00
+								5 0.26
 							</tableData>
 						</table>
 					</product>
 				</sum>
 			</function>
 		</fcs_function>
-		
+
 		<switch name="/systems/fcs/aileron-l/switch">
-			<default value="/systems/fcs/aileron-droop"/>
+			<default value="/systems/fcs/aileron-droop" />
 			<test logic="AND" value="/systems/fcs/aileron-l/extended">
 				/systems/fcs/aileron-l/actuator-enabled eq 1
 				spoilers/anti-droop-final ne 0
@@ -192,30 +229,30 @@
 				<max>1.0</max>
 			</clipto>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/aileron-l/cmd-deg">
 			<input>/systems/fcs/aileron-l/switch</input>
 			<gain>25</gain>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/aileron-l/rate">
-			<default value="/systems/fcs/aileron-droop-rate"/>
+			<default value="/systems/fcs/aileron-droop-rate" />
 			<test value="82">
 				/systems/fcs/aileron-l/actuator-enabled eq 1
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/aileron-l/final-actuator">
 			<input>/systems/fcs/aileron-l/cmd-deg</input>
 			<rate_limit>/systems/fcs/aileron-l/rate</rate_limit>
 			<lag>26.5</lag>
 			<output>/systems/fcs/aileron-l/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Aileron R">
-		
+
 		<summer name="/systems/fcs/aileron-r/input">
 			<input>/systems/fbw/aileron-output</input>
 			<input>/systems/fbw/laf/output-ail</input>
@@ -224,7 +261,7 @@
 				<max>1.0</max>
 			</clipto>
 		</summer>
-		
+
 		<fcs_function name="/systems/fcs/aileron-r/extended">
 			<function>
 				<product>
@@ -236,7 +273,7 @@
 				</product>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/aileron-r/retracted">
 			<function>
 				<sum>
@@ -250,17 +287,17 @@
 						<table>
 							<independentVar lookup="row">/fdm/jsbsim/fcs/flap-pos-deg</independentVar>
 							<tableData>
-								1  0.00
-								5  0.26
+								1 0.00
+								5 0.26
 							</tableData>
 						</table>
 					</product>
 				</sum>
 			</function>
 		</fcs_function>
-		
+
 		<switch name="/systems/fcs/aileron-r/switch">
-			<default value="/systems/fcs/aileron-droop"/>
+			<default value="/systems/fcs/aileron-droop" />
 			<test logic="AND" value="/systems/fcs/aileron-r/extended">
 				/systems/fcs/aileron-r/actuator-enabled eq 1
 				spoilers/anti-droop-final ne 0
@@ -275,30 +312,30 @@
 				<max>1.0</max>
 			</clipto>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/aileron-r/cmd-deg">
 			<input>/systems/fcs/aileron-r/switch</input>
 			<gain>25</gain>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/aileron-r/rate">
-			<default value="/systems/fcs/aileron-droop-rate"/>
+			<default value="/systems/fcs/aileron-droop-rate" />
 			<test value="82">
 				/systems/fcs/aileron-r/actuator-enabled eq 1
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/aileron-r/final-actuator">
 			<input>/systems/fcs/aileron-r/cmd-deg</input>
 			<rate_limit>/systems/fcs/aileron-r/rate</rate_limit>
 			<lag>26.5</lag>
 			<output>/systems/fcs/aileron-r/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Elevator Common">
-		
+
 		<aerosurface_scale name="/systems/fcs/elevator-output-scale">
 			<input>/systems/fbw/elevator-output</input>
 			<range>
@@ -306,58 +343,51 @@
 				<max>0.5</max> <!-- 15 degrees -->
 			</range>
 		</aerosurface_scale>
-		
+
 		<switch name="/systems/fcs/elevator-output-switch">
-			<default value="/systems/fcs/elevator-output-scale"/>
+			<default value="/systems/fcs/elevator-output-scale" />
 			<test value="/systems/fbw/elevator-output">
 				/velocities/groundspeed-kt lt 75
 			</test>
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Elevator L">
-		
+
 		<switch name="/systems/fcs/elevator-l/pressure-switch-or">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				<test logic="AND">
 					<test logic="OR">
 						/systems/fctl/elac1 eq 1
 						/systems/fctl/sec1 eq 1
 					</test>
-					/systems/hydraulic/blue-psi ge 1500
-				</test>
+					/systems/hydraulic/blue-psi ge 1500 </test>
 				<test logic="AND">
 					<test logic="OR">
 						/systems/fctl/elac2 eq 1
 						/systems/fctl/sec2 eq 1
 					</test>
-					/systems/hydraulic/green-psi ge 1500
-				</test>
+					/systems/hydraulic/green-psi ge 1500 </test>
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/elevator-l/actuator-enabled">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1"> <!-- Don't use pressure-switch-or -->
 				<test logic="OR">
 					/systems/hydraulic/blue-psi ge 1500
 					/systems/hydraulic/green-psi ge 1500
 				</test>
-				/systems/failures/elevator-left eq 0
-			</test>
+				/systems/failures/elevator-left eq 0 </test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/elevator-l/switch">
-			<default value="/systems/fcs/elevator-droop"/>
-			<test logic="AND" value="0"> <!-- Only pitch trim available -->
-				/systems/fcs/elevator-l/actuator-enabled eq 1
-				/systems/fctl/elac1 eq 0
-				/systems/fctl/sec1 eq 0
-				/systems/fctl/elac2 eq 0
-				/systems/fctl/sec2 eq 0
-			</test>
+			<default value="/systems/fcs/elevator-droop" />
+			<test logic="AND" value="0"> <!-- Only pitch trim available --> /systems/fcs/elevator-l/actuator-enabled eq 1
+				/systems/fctl/elac1 eq 0 /systems/fctl/sec1 eq 0 /systems/fctl/elac2 eq 0
+				/systems/fctl/sec2 eq 0 </test>
 			<test logic="AND" value="/systems/fcs/elevator-output-switch">
 				/systems/fcs/elevator-l/actuator-enabled eq 1
 				/systems/fcs/elevator-l/pressure-switch-or eq 1
@@ -367,7 +397,7 @@
 				<max>1.0</max>
 			</clipto>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/elevator-l/cmd-deg">
 			<input>/systems/fcs/elevator-l/switch</input>
 			<gain>30</gain>
@@ -376,65 +406,58 @@
 				<max>15</max>
 			</clipto>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/elevator-l/rate">
-			<default value="/systems/fcs/elevator-droop-rate"/>
+			<default value="/systems/fcs/elevator-droop-rate" />
 			<test value="82">
 				/systems/fcs/elevator-l/actuator-enabled eq 1
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/elevator-l/final-actuator">
 			<input>/systems/fcs/elevator-l/cmd-deg</input>
 			<rate_limit>/systems/fcs/elevator-l/rate</rate_limit>
 			<lag>26.5</lag>
 			<output>/systems/fcs/elevator-l/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Elevator R">
-		
+
 		<switch name="/systems/fcs/elevator-r/pressure-switch-or">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				<test logic="AND">
 					<test logic="OR">
 						/systems/fctl/elac1 eq 1
 						/systems/fctl/sec1 eq 1
 					</test>
-					/systems/hydraulic/blue-psi ge 1500
-				</test>
+					/systems/hydraulic/blue-psi ge 1500 </test>
 				<test logic="AND">
 					<test logic="OR">
 						/systems/fctl/elac2 eq 1
 						/systems/fctl/sec2 eq 1
 					</test>
-					/systems/hydraulic/yellow-psi ge 1500
-				</test>
+					/systems/hydraulic/yellow-psi ge 1500 </test>
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/elevator-r/actuator-enabled">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1"> <!-- Don't use pressure-switch-or -->
 				<test logic="OR">
 					/systems/hydraulic/blue-psi ge 1500
 					/systems/hydraulic/yellow-psi ge 1500
 				</test>
-				/systems/failures/elevator-left eq 0
-			</test>
+				/systems/failures/elevator-left eq 0 </test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/elevator-r/switch">
-			<default value="/systems/fcs/elevator-droop"/>
-			<test logic="AND" value="0"> <!-- Only pitch trim available -->
-				/systems/fcs/elevator-r/actuator-enabled eq 1
-				/systems/fctl/elac1 eq 0
-				/systems/fctl/sec1 eq 0
-				/systems/fctl/elac2 eq 0
-				/systems/fctl/sec2 eq 0
-			</test>
+			<default value="/systems/fcs/elevator-droop" />
+			<test logic="AND" value="0"> <!-- Only pitch trim available --> /systems/fcs/elevator-r/actuator-enabled eq 1
+				/systems/fctl/elac1 eq 0 /systems/fctl/sec1 eq 0 /systems/fctl/elac2 eq 0
+				/systems/fctl/sec2 eq 0 </test>
 			<test logic="AND" value="/systems/fcs/elevator-output-switch">
 				/systems/fcs/elevator-r/actuator-enabled eq 1
 				/systems/fcs/elevator-r/pressure-switch-or eq 1
@@ -444,7 +467,7 @@
 				<max>1.0</max>
 			</clipto>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/elevator-r/cmd-deg">
 			<input>/systems/fcs/elevator-r/switch</input>
 			<gain>30</gain>
@@ -453,27 +476,27 @@
 				<max>15</max>
 			</clipto>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/elevator-r/rate">
-			<default value="/systems/fcs/elevator-droop-rate"/>
+			<default value="/systems/fcs/elevator-droop-rate" />
 			<test value="82">
 				/systems/fcs/elevator-r/actuator-enabled eq 1
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/elevator-r/final-actuator">
 			<input>/systems/fcs/elevator-r/cmd-deg</input>
 			<rate_limit>/systems/fcs/elevator-r/rate</rate_limit>
 			<lag>26.5</lag>
 			<output>/systems/fcs/elevator-r/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Stabilizer">
-		
+
 		<switch name="/systems/fcs/stabilizer/actuator-enabled">
-			<default value="0"/>
+			<default value="0" />
 			<test value="0">
 				/systems/failures/fctl/ths-jam eq 1
 			</test>
@@ -484,14 +507,15 @@
 			</test>
 			<output>/systems/fbw/pitch/stabilizer-enabled</output>
 		</switch>
-		
+
 		<switch name="/systems/fcs/stabilizer/rate">
-			<default value="0"/> <!-- Only mechanical input to hyd actuator. It needs hydraulic power to move -->
+			<default value="0" /> <!-- Only mechanical input to hyd actuator. It needs hydraulic
+			power to move -->
 			<test value="0.25">
 				/systems/fcs/stabilizer/actuator-enabled eq 1
 			</test>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/stabilizer/cmd-deg">
 			<input>/controls/flight/elevator-trim</input>
 			<gain>13.5</gain>
@@ -500,76 +524,70 @@
 				<max>4.0</max>
 			</clipto>
 		</pure_gain>
-		
+
 		<actuator name="/systems/fcs/stabilizer/final-actuator">
 			<input>/systems/fcs/stabilizer/cmd-deg</input>
 			<rate_limit>/systems/fcs/stabilizer/rate</rate_limit>
 			<lag>22.5</lag>
 			<output>/systems/fcs/stabilizer/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Rudder">
-		
+
 		<switch name="/systems/fcs/rudder/pressure-switch-or">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/systems/hydraulic/green-psi ge 1500
 				/systems/hydraulic/blue-psi ge 1500
 				/systems/hydraulic/yellow-psi ge 1500
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fctl/yawdamper-1-active">
-			<default value="0"/>
-			<test logic="AND" value="1">
-				/systems/fctl/fac1-healthy-signal eq 1
-				/systems/hydraulic/green-psi ge 1500
-				<test logic="OR">
-					/systems/navigation/adr/operating-1 eq 1
+			<default value="0" />
+			<test logic="AND" value="1"> /systems/fctl/fac1-healthy-signal eq 1
+				/systems/hydraulic/green-psi ge 1500 <test logic="OR">
+				/systems/navigation/adr/operating-1 eq 1
 					/systems/navigation/adr/operating-3 eq 1
 				</test>
-				/systems/failures/fctl/yaw-damper-1 eq 0
-			</test>
+				/systems/failures/fctl/yaw-damper-1 eq 0 </test>
 		</switch>
-		
+
 		<switch name="/systems/fctl/yawdamper-2-active">
-			<default value="0"/>
-			<test logic="AND" value="1">
-				/systems/fctl/fac2-healthy-signal eq 1
-				/systems/hydraulic/yellow-psi ge 1500
-				<test logic="OR">
-					/systems/navigation/adr/operating-2 eq 1
+			<default value="0" />
+			<test logic="AND" value="1"> /systems/fctl/fac2-healthy-signal eq 1
+				/systems/hydraulic/yellow-psi ge 1500 <test logic="OR">
+				/systems/navigation/adr/operating-2 eq 1
 					/systems/navigation/adr/operating-3 eq 1
 				</test>
-				/systems/failures/fctl/yaw-damper-2 eq 0
-			</test>
+				/systems/failures/fctl/yaw-damper-2 eq 0 </test>
 		</switch>
-		
+
 		<switch name="/systems/fctl/yawdamper-active">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/systems/fctl/yawdamper-1-active eq 1
 				/systems/fctl/yawdamper-2-active eq 1
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/rudder/trim-autopilot">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="/controls/flight/rudder-trim">
 				/it-autoflight/output/ap1 eq 0
 				/it-autoflight/output/ap2 eq 0
 			</test>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/rudder/trim-cmd-deg">
 			<input>/systems/fcs/rudder/trim-autopilot</input>
 			<gain>20</gain>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/rudder/trim-rate">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				<test logic="AND">
 					/systems/electrical/bus/dc-ess ge 25
@@ -581,12 +599,12 @@
 				</test>
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/rudder/trim-deg">
 			<input>/systems/fcs/rudder/trim-cmd-deg</input>
 			<rate_limit>/systems/fcs/rudder/trim-rate</rate_limit>
 		</actuator>
-		
+
 		<aerosurface_scale name="/systems/fcs/rudder/trim-norm">
 			<input>/systems/fcs/rudder/trim-deg</input>
 			<domain>
@@ -598,7 +616,7 @@
 				<max>0.8</max>
 			</range>
 		</aerosurface_scale>
-		
+
 		<summer name="/systems/fcs/rudder/summer">
 			<input>/systems/fbw/rudder-output</input>
 			<input>/systems/fcs/rudder/trim-norm</input>
@@ -607,7 +625,7 @@
 				<max>1</max>
 			</clipto>
 		</summer>
-		
+
 		<fcs_function name="/systems/fcs/rudder/swing-deg">
 			<function>
 				<product>
@@ -629,7 +647,7 @@
 				<max>25.0</max>
 			</clipto>
 		</fcs_function>
-		
+
 		<aerosurface_scale name="/systems/fcs/rudder/swing-norm">
 			<input>/systems/fcs/rudder/swing-deg</input>
 			<domain>
@@ -641,9 +659,9 @@
 				<max>1.0</max>
 			</range>
 		</aerosurface_scale>
-		
+
 		<switch name="/systems/fcs/rudder/switch">
-			<default value="/systems/fcs/rudder/swing-norm"/>
+			<default value="/systems/fcs/rudder/swing-norm" />
 			<test logic="AND" value="/systems/fcs/rudder/summer">
 				/systems/fcs/rudder/pressure-switch-or ne 0
 			</test>
@@ -652,31 +670,32 @@
 				<max>/systems/fbw/yaw/max-deg-scale</max>
 			</clipto>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/rudder/cmd-deg">
 			<input>/systems/fcs/rudder/switch</input>
 			<gain>25</gain>
 		</pure_gain>
-		
+
 		<switch name="/systems/fcs/rudder/rate">
-			<default value="80"/>
-			<test logic="OR" value="25"> <!-- returns to center from centering spring / damping / aero -->
-				/systems/fcs/rudder/pressure-switch-or eq 0
-			</test>
+			<default value="80" />
+			<test logic="OR" value="25"> <!-- returns to center from centering spring / damping /
+				aero --> /systems/fcs/rudder/pressure-switch-or eq 0 </test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/rudder/final-actuator">
 			<input>/systems/fcs/rudder/cmd-deg</input>
 			<rate_limit>/systems/fcs/rudder/rate</rate_limit>
 			<lag>25.5</lag>
 			<output>/systems/fcs/rudder/final-deg</output>
 		</actuator>
-	
+
 	</channel>
-	
-	<channel name="SFCC"> <!-- 40 for IAE, 35 for CFM/PW is simulated here properly, do NOT change it into seperate unless you like buggy behavior! -->
-		
-		<fcs_function name="/controls/flight/flaps-fixed"> <!-- Rounds to 4 figures to fix a potential problem -->
+
+	<channel name="SFCC"> <!-- 40 for IAE, 35 for CFM/PW is simulated here properly, do NOT change it
+		into seperate unless you like buggy behavior! -->
+
+		<fcs_function name="/controls/flight/flaps-fixed"> <!-- Rounds to 4 figures to fix a
+			potential problem -->
 			<function>
 				<quotient>
 					<floor>
@@ -692,129 +711,91 @@
 				</quotient>
 			</function>
 		</fcs_function>
-		
+
 		<switch name="/controls/flight/flaps-input">
-			<default value="0"/> <!-- 0 -->
-			<test logic="AND" value="1"> <!-- 1/1+F -->
-				/controls/flight/flaps-fixed ge 0.2
-				/controls/flight/flaps-fixed lt 0.4
-			</test>
-			<test logic="AND" value="2"> <!-- 2 -->
-				/controls/flight/flaps-fixed ge 0.4
-				/controls/flight/flaps-fixed lt 0.6
-			</test>
-			<test logic="AND" value="3"> <!-- 3 -->
-				/controls/flight/flaps-fixed ge 0.6
-				/controls/flight/flaps-fixed lt 0.8
-			</test>
-			<test logic="AND" value="4"> <!-- FULL -->
-				/controls/flight/flaps-fixed ge 0.8
-			</test>
+			<default value="0" /> <!-- 0 -->
+			<test logic="AND" value="1"> <!-- 1/1+F --> /controls/flight/flaps-fixed ge 0.2
+				/controls/flight/flaps-fixed lt 0.4 </test>
+			<test logic="AND" value="2"> <!-- 2 --> /controls/flight/flaps-fixed ge 0.4
+				/controls/flight/flaps-fixed lt 0.6 </test>
+			<test logic="AND" value="3"> <!-- 3 --> /controls/flight/flaps-fixed ge 0.6
+				/controls/flight/flaps-fixed lt 0.8 </test>
+			<test logic="AND" value="4"> <!-- FULL --> /controls/flight/flaps-fixed ge 0.8 </test>
 			<output>/controls/flight/flaps-input-out</output>
 		</switch>
-		
+
 		<switch name="/controls/flight/flaps-1f-enable"> <!-- Flip flop, controls 1 vs 1+F -->
-			<default value="/controls/flight/flaps-1f-enable"/>
-			<test logic="OR" value="0"> <!-- Reset -->
-				/controls/flight/flaps-input ne 1
-				/instrumentation/airspeed-indicator/indicated-speed-kt ge 210
-			</test>
-			<test logic="AND" value="1"> <!-- 0 to 1 -->
-				/controls/flight/flaps-input eq 1
+			<default value="/controls/flight/flaps-1f-enable" />
+			<test logic="OR" value="0"> <!-- Reset --> /controls/flight/flaps-input ne 1
+				/instrumentation/airspeed-indicator/indicated-speed-kt ge 210 </test>
+			<test logic="AND" value="1"> <!-- 0 to 1 --> /controls/flight/flaps-input eq 1
 				/controls/flight/flaps-input-last eq 0
-				/instrumentation/airspeed-indicator/indicated-speed-kt le 100
-			</test>
-			<test logic="AND" value="1"> <!-- 2/3/FULL to 1 -->
-				/controls/flight/flaps-input eq 1
+				/instrumentation/airspeed-indicator/indicated-speed-kt le 100 </test>
+			<test logic="AND" value="1"> <!-- 2/3/FULL to 1 --> /controls/flight/flaps-input eq 1
 				/controls/flight/flaps-input-last ge 2
-				/instrumentation/airspeed-indicator/indicated-speed-kt lt 210
-			</test>
+				/instrumentation/airspeed-indicator/indicated-speed-kt lt 210 </test>
 		</switch>
-		
-		<pure_gain name="/controls/flight/flaps-input-last"> <!-- This is very important for the logic of the flipflop, do not refactor removing this -->
+
+		<pure_gain name="/controls/flight/flaps-input-last"> <!-- This is very important for the
+			logic of the flipflop, do not refactor removing this -->
 			<input>/controls/flight/flaps-input</input>
 			<gain>1.0</gain>
 		</pure_gain>
-		
+
 		<switch name="/controls/flight/flaps-pos"> <!-- Split 1 and 1+F -->
-			<default value="0"/> <!-- 0 -->
-			<test logic="AND" value="1"> <!-- 1 -->
-				/controls/flight/flaps-fixed ge 0.2
-				/controls/flight/flaps-fixed lt 0.4
-				/controls/flight/flaps-1f-enable ne 1
-			</test>
-			<test logic="AND" value="2"> <!-- 1+F -->
-				/controls/flight/flaps-fixed ge 0.2
-				/controls/flight/flaps-fixed lt 0.4
-				/controls/flight/flaps-1f-enable eq 1
-			</test>
-			<test logic="AND" value="3"> <!-- 2 -->
-				/controls/flight/flaps-fixed ge 0.4
-				/controls/flight/flaps-fixed lt 0.6
-			</test>
-			<test logic="AND" value="4"> <!-- 3 -->
-				/controls/flight/flaps-fixed ge 0.6
-				/controls/flight/flaps-fixed lt 0.8
-			</test>
-			<test logic="AND" value="5"> <!-- FULL -->
-				/controls/flight/flaps-fixed ge 0.8
-			</test>
+			<default value="0" /> <!-- 0 -->
+			<test logic="AND" value="1"> <!-- 1 --> /controls/flight/flaps-fixed ge 0.2
+				/controls/flight/flaps-fixed lt 0.4 /controls/flight/flaps-1f-enable ne 1 </test>
+			<test logic="AND" value="2"> <!-- 1+F --> /controls/flight/flaps-fixed ge 0.2
+				/controls/flight/flaps-fixed lt 0.4 /controls/flight/flaps-1f-enable eq 1 </test>
+			<test logic="AND" value="3"> <!-- 2 --> /controls/flight/flaps-fixed ge 0.4
+				/controls/flight/flaps-fixed lt 0.6 </test>
+			<test logic="AND" value="4"> <!-- 3 --> /controls/flight/flaps-fixed ge 0.6
+				/controls/flight/flaps-fixed lt 0.8 </test>
+			<test logic="AND" value="5"> <!-- FULL --> /controls/flight/flaps-fixed ge 0.8 </test>
 			<output>/controls/flight/flaps-input-out</output>
 		</switch>
-		
+
 		<switch name="/controls/flight/flaps-cmd">
-			<default value="0"/>
-			<test value="10"> <!-- 1+F -->
-				/controls/flight/flaps-pos eq 2
-			</test>
-			<test value="15"> <!-- 2 -->
-				/controls/flight/flaps-pos eq 3
-			</test>
-			<test value="20"> <!-- 3 -->
-				/controls/flight/flaps-pos eq 4
-			</test>
-			<test value="40"> <!-- Or 35 --> <!-- FULL -->
-				/controls/flight/flaps-pos eq 5
-			</test>
+			<default value="0" />
+			<test value="10"> <!-- 1+F --> /controls/flight/flaps-pos eq 2 </test>
+			<test value="15"> <!-- 2 --> /controls/flight/flaps-pos eq 3 </test>
+			<test value="20"> <!-- 3 --> /controls/flight/flaps-pos eq 4 </test>
+			<test value="40"> <!-- Or 35 --> <!-- FULL --> /controls/flight/flaps-pos eq 5 </test>
 			<clipto>
 				<min>0</min>
 				<max>/options/maxflap</max>
 			</clipto>
 		</switch>
-		
+
 		<switch name="/controls/flight/slats-cmd">
-			<default value="0"/>
-			<test value="27"> <!-- FULL -->
-				/controls/flight/flaps-input eq 4
-			</test>
-			<test value="22"> <!-- 2/3 -->
-				/controls/flight/flaps-input ge 2
-			</test>
-			<test value="18"> <!-- 1/1+F -->
-				/controls/flight/flaps-input eq 1
-			</test>
+			<default value="0" />
+			<test value="27"> <!-- FULL --> /controls/flight/flaps-input eq 4 </test>
+			<test value="22"> <!-- 2/3 --> /controls/flight/flaps-input ge 2 </test>
+			<test value="18"> <!-- 1/1+F --> /controls/flight/flaps-input eq 1 </test>
 		</switch>
-		
+
 		<switch name="fcs/sfcc/unit1-avail">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/systems/electrical/bus/dc-ess ge 25
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/sfcc/unit2-avail">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/systems/electrical/bus/dc-2 ge 25
 			</test>
 		</switch>
-	
+
 	</channel>
-	
-	<channel name="Flaps"> <!-- 40 for IAE, 35 for CFM/PW is simulated here properly, do NOT change it into seperate unless you like buggy behavior! -->
-		
+
+	<channel name="Flaps"> <!-- 40 for IAE, 35 for CFM/PW is simulated here properly, do NOT change
+		it into seperate unless you like buggy behavior! -->
+
 		<switch name="fcs/flap-pos-rate">
-			<default value="0.0"/>
+			<default value="0.0" />
 			<test value="100">
 				/systems/acconfig/autoconfig-running eq 1
 			</test>
@@ -843,13 +824,13 @@
 				/systems/hydraulic/yellow-psi ge 1500
 			</test>
 		</switch>
-		
+
 		<actuator name="rubbish/flap-pos-deg">
 			<input>/controls/flight/flaps-cmd</input>
 			<rate_limit>fcs/flap-pos-rate</rate_limit>
 			<output>fcs/flap-pos-deg</output>
 		</actuator>
-		
+
 		<aerosurface_scale name="rubbish/flap-pos-norm">
 			<input>fcs/flap-pos-deg</input>
 			<domain>
@@ -862,25 +843,25 @@
 			</range>
 			<output>fcs/flap-pos-norm</output>
 		</aerosurface_scale>
-	
+
 	</channel>
-	
+
 	<channel name="Slats">
-		
+
 		<switch name="fcs/sfcc/slat-locked-cmd">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1">
 				<test logic="OR">
 					fcs/sfcc/unit1-avail eq 1
 					fcs/sfcc/unit2-avail eq 1
 				</test>
-				fcs/sfcc/slat-locked-cmd eq 1
-				/systems/navigation/adr/operating-2 eq 1
-				<test logic="OR">
+				fcs/sfcc/slat-locked-cmd eq 1 /systems/navigation/adr/operating-2 eq 1 <test
+					logic="OR">
 					/gear/gear[1]/wow ne 1
 					/systems/navigation/adr/output/cas-2 ge 60
 				</test>
-				<test logic="OR">
+				<test
+					logic="OR">
 					/systems/navigation/adr/output/aoa-2 gt 7.6
 					/systems/navigation/adr/output/cas-2 lt 154
 				</test>
@@ -890,31 +871,30 @@
 					fcs/sfcc/unit1-avail eq 1
 					fcs/sfcc/unit2-avail eq 1
 				</test>
-				fcs/sfcc/slat-locked-cmd eq 0
-				/controls/flight/flaps-input ne 0
-				/systems/navigation/adr/operating-2 eq 1
-				<test logic="OR">
+				fcs/sfcc/slat-locked-cmd eq 0 /controls/flight/flaps-input ne 0
+				/systems/navigation/adr/operating-2 eq 1 <test logic="OR">
 					/gear/gear[1]/wow ne 1
 					/systems/navigation/adr/output/cas-2 ge 60
 				</test>
-				<test logic="OR">
+				<test
+					logic="OR">
 					/systems/navigation/adr/output/aoa-2 gt 8.5
 					/systems/navigation/adr/output/cas-2 lt 148
 				</test>
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/sfcc/slat-locked">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1">
 				/controls/flight/flaps-input eq 0
 				fcs/slat-pos-deg le 18.01
 				fcs/sfcc/slat-locked-cmd eq 1
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/slat-pos-rate">
-			<default value="0.0"/>
+			<default value="0.0" />
 			<test logic="AND" value="0.0">
 				/controls/flight/flaps-input eq 0
 				fcs/slat-pos-deg le 18.01
@@ -948,13 +928,13 @@
 				/systems/hydraulic/green-psi ge 1500
 			</test>
 		</switch>
-		
+
 		<actuator name="rubbish/slat-pos-deg">
 			<input>/controls/flight/slats-cmd</input>
 			<rate_limit>fcs/slat-pos-rate</rate_limit>
 			<output>fcs/slat-pos-deg</output>
 		</actuator>
-		
+
 		<aerosurface_scale name="rubbish/slat-pos-norm">
 			<input>fcs/slat-pos-deg</input>
 			<domain>
@@ -967,25 +947,25 @@
 			</range>
 			<output>fcs/slat-pos-norm</output>
 		</aerosurface_scale>
-	
+
 	</channel>
-	
+
 	<channel name="Gear Common">
-		
+
 		<switch name="/controls/gear/lever">
-			<default value="1"/>
+			<default value="1" />
 			<test value="0">
 				/controls/gear/lever-cockpit le 1
 			</test>
 			<output>/controls/gear/gear-down</output> <!-- For TOO LOW GEAR callout -->
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Nose Gear">
-		
+
 		<switch name="/systems/gear/unit[0]/rate-incr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -993,17 +973,13 @@
 			<test value="0">
 				/systems/failures/gear/nose-actuator eq 1
 			</test>
-			<test value="0.0833333"> <!-- About 12 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
-			<test logic="AND" value="0.0166667"> <!-- About 60 sec -->
-				/controls/hydraulic/switches/gear-gravity-ext eq 1
-				/accelerations/pilot-g ge 0.5
-			</test>
+			<test value="0.0833333"> <!-- About 12 sec --> /systems/hydraulic/green-psi ge 1500 </test>
+			<test logic="AND" value="0.0166667"> <!-- About 60 sec --> /controls/hydraulic/switches/gear-gravity-ext eq 1
+				/accelerations/pilot-g ge 0.5 </test>
 		</switch>
-		
+
 		<switch name="/systems/gear/unit[0]/rate-decr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -1011,24 +987,22 @@
 			<test value="0">
 				/systems/failures/gear/nose-actuator eq 1
 			</test>
-			<test value="0.0952381"> <!-- About 10.5 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
+			<test value="0.0952381"> <!-- About 10.5 sec --> /systems/hydraulic/green-psi ge 1500 </test>
 		</switch>
-		
+
 		<actuator name="/systems/gear/unit[0]/pos-actuator">
 			<input>/controls/gear/lever</input>
 			<rate_limit sense="incr">/systems/gear/unit[0]/rate-incr</rate_limit>
 			<rate_limit sense="decr">/systems/gear/unit[0]/rate-decr</rate_limit>
 			<output>gear/unit[0]/pos-norm</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Left Main Gear">
-		
+
 		<switch name="/systems/gear/unit[1]/rate-incr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -1036,17 +1010,13 @@
 			<test value="0">
 				/systems/failures/gear/left-actuator eq 1
 			</test>
-			<test value="0.0625"> <!-- About 16 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
-			<test logic="AND" value="0.0222222"> <!-- About 45 sec -->
-				/controls/hydraulic/switches/gear-gravity-ext eq 1
-				/accelerations/pilot-g ge 0.5
-			</test>
+			<test value="0.0625"> <!-- About 16 sec --> /systems/hydraulic/green-psi ge 1500 </test>
+			<test logic="AND" value="0.0222222"> <!-- About 45 sec --> /controls/hydraulic/switches/gear-gravity-ext eq 1
+				/accelerations/pilot-g ge 0.5 </test>
 		</switch>
-		
+
 		<switch name="/systems/gear/unit[1]/rate-decr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -1054,24 +1024,22 @@
 			<test value="0">
 				/systems/failures/gear/left-actuator eq 1
 			</test>
-			<test value="0.1111111"> <!-- About 9 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
+			<test value="0.1111111"> <!-- About 9 sec --> /systems/hydraulic/green-psi ge 1500 </test>
 		</switch>
-		
+
 		<actuator name="/systems/gear/unit[1]/pos-actuator">
 			<input>/controls/gear/lever</input>
 			<rate_limit sense="incr">/systems/gear/unit[1]/rate-incr</rate_limit>
 			<rate_limit sense="decr">/systems/gear/unit[1]/rate-decr</rate_limit>
 			<output>gear/unit[1]/pos-norm</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Right Main Gear">
-		
+
 		<switch name="/systems/gear/unit[2]/rate-incr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -1079,17 +1047,13 @@
 			<test value="0">
 				/systems/failures/gear/right-actuator eq 1
 			</test>
-			<test value="0.0625"> <!-- About 16 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
-			<test logic="AND" value="0.0222222"> <!-- About 45 sec -->
-				/controls/hydraulic/switches/gear-gravity-ext eq 1
-				/accelerations/pilot-g ge 0.5
-			</test>
+			<test value="0.0625"> <!-- About 16 sec --> /systems/hydraulic/green-psi ge 1500 </test>
+			<test logic="AND" value="0.0222222"> <!-- About 45 sec --> /controls/hydraulic/switches/gear-gravity-ext eq 1
+				/accelerations/pilot-g ge 0.5 </test>
 		</switch>
-		
+
 		<switch name="/systems/gear/unit[2]/rate-decr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="1000">
 				/systems/acconfig/autoconfig-running eq 1
 				position/wow eq 1
@@ -1097,22 +1061,20 @@
 			<test value="0">
 				/systems/failures/gear/right-actuator eq 1
 			</test>
-			<test value="0.1111111"> <!-- About 9 sec -->
-				/systems/hydraulic/green-psi ge 1500
-			</test>
+			<test value="0.1111111"> <!-- About 9 sec --> /systems/hydraulic/green-psi ge 1500 </test>
 		</switch>
-		
+
 		<actuator name="/systems/gear/unit[2]/pos-actuator">
 			<input>/controls/gear/lever</input>
 			<rate_limit sense="incr">/systems/gear/unit[2]/rate-incr</rate_limit>
 			<rate_limit sense="decr">/systems/gear/unit[2]/rate-decr</rate_limit>
 			<output>gear/unit[2]/pos-norm</output>
 		</actuator>
-	
+
 	</channel>
-	
+
 	<channel name="Gear Misc">
-		
+
 		<fcs_function name="/systems/gear/all-norm">
 			<function>
 				<product>
@@ -1122,49 +1084,37 @@
 				</product>
 			</function>
 		</fcs_function>
-		
+
 		<switch name="/systems/gear/unit[0]/status">
-			<default value="1"/> <!-- In transit -->
-			<test logic="AND" value="0"> <!-- Up -->
-				/controls/gear/lever-cockpit eq 0
-				/systems/gear/unit[0]/pos-actuator lt 0.01
-			</test>
-			<test logic="AND" value="2"> <!-- Down -->
-				/controls/gear/lever-cockpit eq 3
-				/systems/gear/unit[0]/pos-actuator gt 0.99
-			</test>
+			<default value="1" /> <!-- In transit -->
+			<test logic="AND" value="0"> <!-- Up --> /controls/gear/lever-cockpit eq 0
+				/systems/gear/unit[0]/pos-actuator lt 0.01 </test>
+			<test logic="AND" value="2"> <!-- Down --> /controls/gear/lever-cockpit eq 3
+				/systems/gear/unit[0]/pos-actuator gt 0.99 </test>
 		</switch>
-		
+
 		<switch name="/systems/gear/unit[1]/status">
-			<default value="1"/> <!-- In transit -->
-			<test logic="AND" value="0"> <!-- Up -->
-				/controls/gear/lever-cockpit eq 0
-				/systems/gear/unit[1]/pos-actuator lt 0.01
-			</test>
-			<test logic="AND" value="2"> <!-- Down -->
-				/controls/gear/lever-cockpit eq 3
-				/systems/gear/unit[1]/pos-actuator gt 0.99
-			</test>
+			<default value="1" /> <!-- In transit -->
+			<test logic="AND" value="0"> <!-- Up --> /controls/gear/lever-cockpit eq 0
+				/systems/gear/unit[1]/pos-actuator lt 0.01 </test>
+			<test logic="AND" value="2"> <!-- Down --> /controls/gear/lever-cockpit eq 3
+				/systems/gear/unit[1]/pos-actuator gt 0.99 </test>
 		</switch>
-		
+
 		<switch name="/systems/gear/unit[2]/status">
-			<default value="1"/> <!-- In transit -->
-			<test logic="AND" value="0"> <!-- Up -->
-				/controls/gear/lever-cockpit eq 0
-				/systems/gear/unit[2]/pos-actuator lt 0.01
-			</test>
-			<test logic="AND" value="2"> <!-- Down -->
-				/controls/gear/lever-cockpit eq 3
-				/systems/gear/unit[2]/pos-actuator gt 0.99
-			</test>
+			<default value="1" /> <!-- In transit -->
+			<test logic="AND" value="0"> <!-- Up --> /controls/gear/lever-cockpit eq 0
+				/systems/gear/unit[2]/pos-actuator lt 0.01 </test>
+			<test logic="AND" value="2"> <!-- Down --> /controls/gear/lever-cockpit eq 3
+				/systems/gear/unit[2]/pos-actuator gt 0.99 </test>
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Tiller">
-		
+
 		<switch name="/controls/gear/steering-switched">
-			<default value="/systems/fbw/sidestick/yaw-input"/>
+			<default value="/systems/fbw/sidestick/yaw-input" />
 			<test value="0">
 				/gear/gear[0]/wow ne 1
 			</test>
@@ -1175,97 +1125,99 @@
 				/controls/flight/aileron-drives-tiller eq 1
 			</test>
 		</switch>
-		
+
 		<scheduled_gain name="/systems/fbw/tiller-handle-scheduled">
 			<input>/controls/gear/steering-switched</input>
 			<table>
 				<independentVar lookup="row">/velocities/groundspeed-kt</independentVar>
 				<independentVar lookup="column">/systems/acconfig/options/separate-tiller-axis</independentVar>
 				<tableData>
-					      0  1
-					 0.5  0  0
-					 1.0  1  1
-					20.0  1  1
-					70.0  0  1
+					0 1
+					0.5 0 0
+					1.0 1 1
+					20.0 1 1
+					70.0 0 1
 				</tableData>
 			</table>
 		</scheduled_gain>
-		
+
 		<actuator name="/systems/fbw/tiller-handle-cmd">
 			<input>/systems/fbw/tiller-handle-scheduled</input>
 			<rate_limit>0.16</rate_limit> <!-- 12/75 -->
 		</actuator>
-		
+
 		<pure_gain name="/controls/gear/steering-deg">
 			<input>/controls/gear/steering</input>
 			<gain>75</gain>
 		</pure_gain>
-		
+
 		<pure_gain name="/systems/fcs/tiller/autopush-cmd-deg">
 			<input>/systems/fcs/tiller/autopush-cmd</input>
 			<gain>75</gain>
 		</pure_gain>
-		
+
 		<scheduled_gain name="/systems/fcs/tiller/fmgc-cmd-deg">
 			<input>/systems/fbw/fmgc/yaw-cmd</input>
 			<table>
 				<independentVar lookup="row">/velocities/groundspeed-kt</independentVar>
 				<tableData>
-					  0.5  0
-					  1.0  6
-					 40.0  6
-					130.0  0
+					0.5 0
+					1.0 6
+					40.0 6
+					130.0 0
 				</tableData>
 			</table>
 		</scheduled_gain>
-		
+
 		<switch name="/systems/fcs/tiller/rudder-cmd-input">
-			<default value="/systems/fbw/sidestick/yaw-input"/>
+			<default value="/systems/fbw/sidestick/yaw-input" />
 			<test value="/systems/fbw/sidestick/roll-input">
 				/controls/flight/aileron-drives-tiller eq 1
 			</test>
 		</switch>
-		
+
 		<pure_gain name="/systems/fcs/tiller/rudder-cmd-input-deg">
 			<input>/systems/fcs/tiller/rudder-cmd-input</input>
 			<gain>75</gain>
 		</pure_gain>
-		
-		<fcs_function name="/systems/fcs/tiller/rudder-cmd-deg"> <!-- Combines rudder and tiller into just rudder -->
+
+		<fcs_function name="/systems/fcs/tiller/rudder-cmd-deg"> <!-- Combines rudder and tiller into
+			just rudder -->
 			<function>
 				<table>
-					<independentVar lookup="row">zero</independentVar> <!-- Take advantage of the table lookup to interpolate -->
+					<independentVar lookup="row">zero</independentVar> <!-- Take advantage of the
+					table lookup to interpolate -->
 					<independentVar lookup="column">/systems/fcs/tiller/rudder-cmd-input-deg</independentVar>
 					<independentVar lookup="table">/velocities/groundspeed-kt</independentVar>
 					<tableData breakPoint="0.5">
-						  -75 -66 -40 -20 -1  1  20  40  66  75
-						0   0   0   0   0  0  0   0   0   0   0
-						1   0   0   0   0  0  0   0   0   0   0
+						-75 -66 -40 -20 -1 1 20 40 66 75
+						0 0 0 0 0 0 0 0 0 0 0
+						1 0 0 0 0 0 0 0 0 0 0
 					</tableData>
 					<tableData breakPoint="1.0">
-						  -75 -66 -40 -20 -1  1  20  40  66  75
-						0 -75 -45 -15  -4  0  0   4  15  45  75
-						1 -75 -45 -15  -4  0  0   4  15  45  75
+						-75 -66 -40 -20 -1 1 20 40 66 75
+						0 -75 -45 -15 -4 0 0 4 15 45 75
+						1 -75 -45 -15 -4 0 0 4 15 45 75
 					</tableData>
 					<tableData breakPoint="20">
-						  -75 -66 -40 -20 -1  1  20  40  66  75
-						0 -75 -45 -15  -4  0  0   4  15  45  75
-						1 -75 -45 -15  -4  0  0   4  15  45  75
+						-75 -66 -40 -20 -1 1 20 40 66 75
+						0 -75 -45 -15 -4 0 0 4 15 45 75
+						1 -75 -45 -15 -4 0 0 4 15 45 75
 					</tableData>
 					<tableData breakPoint="40">
-						  -75  0  75
-						0  -6  0  6
-						1  -6  0  6
+						-75 0 75
+						0 -6 0 6
+						1 -6 0 6
 					</tableData>
 					<tableData breakPoint="130">
-						  -75  0  75
-						0   0  0  0
-						1   0  0  0
+						-75 0 75
+						0 0 0 0
+						1 0 0 0
 					</tableData>
 				</table>
 			</function>
 		</fcs_function>
-		
+
 		<fcs_function name="/systems/fcs/tiller/tiller-cmd-deg">
 			<function>
 				<sum>
@@ -1273,11 +1225,11 @@
 						<independentVar lookup="row">/velocities/groundspeed-kt</independentVar>
 						<independentVar lookup="column">/controls/gear/steering-deg</independentVar>
 						<tableData>
-							     -75 -66 -40 -20 -1  1  20  40  66  75
-							 0.5   0   0   0   0  0  0   0   0   0   0
-							 1.0 -75 -45 -15  -4  0  0   4  15  45  75
-							20.0 -75 -45 -15  -4  0  0   4  15  45  75
-							70.0   0   0   0   0  0  0   0   0   0   0
+							-75 -66 -40 -20 -1 1 20 40 66 75
+							0.5 0 0 0 0 0 0 0 0 0 0
+							1.0 -75 -45 -15 -4 0 0 4 15 45 75
+							20.0 -75 -45 -15 -4 0 0 4 15 45 75
+							70.0 0 0 0 0 0 0 0 0 0 0
 						</tableData>
 					</table>
 					<product>
@@ -1285,19 +1237,19 @@
 						<table>
 							<independentVar lookup="row">/velocities/groundspeed-kt</independentVar>
 							<tableData>
-								  0.5  0
-								  1.0  6
-								 40.0  6
-								130.0  0
+								0.5 0
+								1.0 6
+								40.0 6
+								130.0 0
 							</tableData>
 						</table>
 					</product>
 				</sum>
 			</function>
 		</fcs_function>
-		
+
 		<switch name="/systems/fcs/tiller/cmd-deg">
-			<default value="/systems/fcs/tiller/rudder-cmd-deg"/>
+			<default value="/systems/fcs/tiller/rudder-cmd-deg" />
 			<test value="0">
 				/gear/gear[0]/wow ne 1
 			</test>
@@ -1315,9 +1267,9 @@
 				<max>75</max>
 			</clipto>
 		</switch>
-		
+
 		<switch name="/systems/fcs/tiller/elec-pwr">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/systems/electrical/bus/ac-1 ge 110
 				/systems/electrical/bus/ac-2 ge 110
@@ -1325,24 +1277,20 @@
 				/systems/electrical/bus/dc-2 ge 25
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/tiller/hyd-pwr">
-			<default value="0"/>
-			<test logic="AND" value="1">
-				position/wow eq 1
-				/systems/fcs/tiller/elec-pwr eq 1
-				/systems/hydraulic/yellow-psi ge 1500
-				/sim/model/autopush/connected eq 0
-				/controls/gear/nws-switch eq 1
-				<test logic="OR">
+			<default value="0" />
+			<test logic="AND" value="1"> position/wow eq 1 /systems/fcs/tiller/elec-pwr eq 1
+				/systems/hydraulic/yellow-psi ge 1500 /sim/model/autopush/connected eq 0
+				/controls/gear/nws-switch eq 1 <test logic="OR">
 					/engines/engine[0]/state eq 3
 					/engines/engine[1]/state eq 3
 				</test>
 			</test>
 		</switch>
-		
+
 		<switch name="/systems/fcs/tiller/rate">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="75">
 				/sim/model/autopush/connected eq 1
 				/systems/acconfig/autoconfig-running eq 1
@@ -1351,37 +1299,37 @@
 				/systems/fcs/tiller/hyd-pwr eq 1
 			</test>
 		</switch>
-		
+
 		<actuator name="/systems/fcs/tiller/actuator">
 			<input>/systems/fcs/tiller/cmd-deg</input>
 			<rate_limit>/systems/fcs/tiller/rate</rate_limit>
 			<lag>24.5</lag>
 			<output>fcs/steer-pos-deg[0]</output>
 		</actuator>
-		
+
 		<switch name="/systems/fcs/tiller/pushback-steer-deg">
-			<default value="0"/>
+			<default value="0" />
 			<test value="/systems/fcs/tiller/actuator">
 				/sim/model/autopush/connected eq 1
 			</test>
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Brakes">
-		
+
 		<actuator name="fcs/brake-left">
 			<input>/controls/gear/brake-left</input>
 			<rate_limit>2</rate_limit>
 		</actuator>
-		
+
 		<actuator name="fcs/brake-right">
 			<input>/controls/gear/brake-right</input>
 			<rate_limit>2</rate_limit>
 		</actuator>
-		
+
 		<switch name="fcs/brake-avail">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="OR" value="1">
 				/services/chocks/enable eq 1
 				/systems/hydraulic/green-psi ge 2500
@@ -1390,7 +1338,7 @@
 			</test>
 			<output>fcs/brake-avail</output>
 		</switch>
-		
+
 		<fcs_function name="fcs/left-brake-input">
 			<function>
 				<product>
@@ -1411,20 +1359,20 @@
 				<max>1.0</max>
 			</clipto>
 		</fcs_function>
-		
+
 		<actuator name="fcs/left-brake-actuator">
 			<input>fcs/left-brake-input</input>
 			<rate_limit>10</rate_limit>
 		</actuator>
-		
+
 		<switch name="rubbish/left-brake-cmd-norm">
-			<default value="fcs/left-brake-actuator"/>
+			<default value="fcs/left-brake-actuator" />
 			<test value="1">
 				/systems/acconfig/autoconfig-running eq 1
 			</test>
 			<output>fcs/left-brake-cmd-norm</output>
 		</switch>
-		
+
 		<fcs_function name="fcs/right-brake-input">
 			<function>
 				<product>
@@ -1445,26 +1393,26 @@
 				<max>1.0</max>
 			</clipto>
 		</fcs_function>
-		
+
 		<actuator name="fcs/right-brake-actuator">
 			<input>fcs/right-brake-input</input>
 			<rate_limit>10</rate_limit>
 		</actuator>
-		
+
 		<switch name="rubbish/right-brake-cmd-norm">
-			<default value="fcs/right-brake-actuator"/>
+			<default value="fcs/right-brake-actuator" />
 			<test value="1">
 				/systems/acconfig/autoconfig-running eq 1
 			</test>
 			<output>fcs/right-brake-cmd-norm</output>
 		</switch>
-	
+
 	</channel>
-	
+
 	<channel name="Wipers">
-	
+
 		<switch name="fcs/left-wiper-cmd">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="0">
 				fcs/left-wiper-pos-norm gt 0.001
 				fcs/left-wiper-has-been-1 eq 1
@@ -1474,9 +1422,9 @@
 				/controls/switches/wiperLspd ne 0
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/left-wiper-has-been-1">
-			<default value="0"/>
+			<default value="0" />
 			<test value="0">
 				fcs/left-wiper-pos-norm le 0.001
 			</test>
@@ -1487,9 +1435,9 @@
 				fcs/left-wiper-pos-norm ge 0.999
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/left-wiper-speed">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="fcs/left-wiper-speed">
 				/controls/switches/wiperLspd eq 0
 				fcs/left-wiper-pos-norm ge 0.001
@@ -1504,14 +1452,14 @@
 				/systems/electrical/bus/dc-1 ge 25
 			</test>
 		</switch>
-		
+
 		<actuator name="fcs/left-wiper-pos-norm">
 			<input>fcs/left-wiper-cmd</input>
 			<rate_limit>fcs/left-wiper-speed</rate_limit>
 		</actuator>
-		
+
 		<switch name="fcs/right-wiper-cmd">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="0">
 				fcs/right-wiper-pos-norm gt 0.001
 				fcs/right-wiper-has-been-1 eq 1
@@ -1521,9 +1469,9 @@
 				/controls/switches/wiperRspd ne 0
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/right-wiper-has-been-1">
-			<default value="0"/>
+			<default value="0" />
 			<test value="0">
 				fcs/right-wiper-pos-norm le 0.001
 			</test>
@@ -1534,9 +1482,9 @@
 				fcs/right-wiper-pos-norm ge 0.999
 			</test>
 		</switch>
-		
+
 		<switch name="fcs/right-wiper-speed">
-			<default value="0"/>
+			<default value="0" />
 			<test logic="AND" value="fcs/right-wiper-speed">
 				/controls/switches/wiperRspd eq 0
 				fcs/right-wiper-pos-norm ge 0.001
@@ -1551,12 +1499,12 @@
 				/systems/electrical/bus/dc-2 ge 25
 			</test>
 		</switch>
-		
+
 		<actuator name="fcs/right-wiper-pos-norm">
 			<input>fcs/right-wiper-cmd</input>
 			<rate_limit>fcs/right-wiper-speed</rate_limit>
 		</actuator>
-		
+
 	</channel>
 
 </system>

--- a/Systems/a320-fcs.xml
+++ b/Systems/a320-fcs.xml
@@ -23,11 +23,11 @@
 							</product>
 
 							<!-- LEMAC position in meters -->
-							<value>-3.508</value>
+							<value>-3.6286475</value>
 						</difference>
 
 						<!-- MAC length in meters -->
-						<value>4.193</value>
+						<value>4.1935</value>
 					</quotient>
 
 					<!-- Convert ratio to percent -->


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes

This PR adds a **CG %MAC computation** to the A320 FCS and clamps the exported value to a **safe 0–100% range**.

The raw CG %MAC math itself is unchanged and still based on aircraft geometry (CGx, LEMAC, MAC). The clamp only affects the *published output* to prevent extreme or unrealistic loading configurations (e.g. all weight fully forward with no fuel) from producing negative values that could break downstream logic assuming a 0–100% range.

**Important notes:**

* This PR is the **intended and correct version** to review and merge.
* An earlier attempt on my side ended up messy due to git history confusion.
* The relatively large diff is caused by **XML auto-formatting**, not by large-scale logic changes. The actual functional change is limited to the CG %MAC computation and clamping.

### Screenshots (optional)

N/A (logic-only FCS change).

### Bugs fixed (if any)

* Prevents negative CG %MAC values from appearing in extreme/unrealistic loading cases, which could otherwise break dependent systems assuming a 0–100% range.

### Checklist:

* [x] My changes follow the Contributing Guidelines.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.

<!-- If your changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
