### PR TITLE
Fix rate_limit sense typo in misc transient timers

### DIFF
--- a/Systems/a320-misc.xml
+++ b/Systems/a320-misc.xml
@@ -533,7 +533,7 @@
 		<actuator name="/instrumentation/iesi/power/power-transient-timer">
 			<input>/instrumentation/iesi/power/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/iesi/power/power-on">
@@ -675,7 +675,7 @@
 		<actuator name="/instrumentation/displays/du3/power-transient-timer">
 			<input>/instrumentation/displays/du3/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/displays/du3/power-on">
@@ -712,7 +712,7 @@
 		<actuator name="/instrumentation/displays/du4/power-transient-timer">
 			<input>/instrumentation/displays/du4/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/displays/du4/power-on">


### PR DESCRIPTION
### Describe the bug
In Systems/a320-misc.xml, three transient timer rate_limit attributes contain a typo: sene="incr" is used instead of the correct sense="incr".

### Expected behaviour
Those three rate_limit attributes should use the canonical sense="incr" spelling, consistent with other rate_limit sense="incr|decr" usage in the same file.

### System :
OS: Windows 11
FlightGear version: 2024.1
A320 Version: revision 2507

### Additional context
The change is minimal and local: it only replaces sene="incr" with sense="incr" in exactly three rate_limit attribute occurrences in Systems/a320-misc.xml, with no other edits (including whitespace) and no other files modified.

### Checklist:
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->