### PR TITLE
Fix EVAC CAPT & PUSR / PURS switch sound call

### DIFF
--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -29648,7 +29648,7 @@
 			</binding>
 			<binding>
 				<command>nasal</command>
-				<script>libraries.Sound.switch1();</script>
+				<script>setprop("sim/sound/switch1", 1);</script>
 			</binding>
 		</action>
 		<hovered>


### PR DESCRIPTION
**Describe the bug**
Toggling the two-position switch labeled "CAPT & PUSR / PURS" triggers a Nasal runtime error in the console:
> 527.81 [ALRT]:nasal Nasal runtime error: No such member: Sound
> 527.81 [ALRT]:nasal at , line 1

**To Reproduce**
Steps to reproduce the behaviour:
1. Toggle the "CAPT & PUSR / PURS" switch.
2. Observe the Nasal runtime error in the console.

**Expected behaviour**
Toggling the switch should not produce any Nasal runtime error, and the switch sound should be handled consistently with other two-position switches.

**Screenshots**
No screenshots provided.

**System (please complete the following information):**
 - OS: Windows 11
 - FlightGear version: 2024.1
 - A320 Version: revision 2507

**Additional context**
The switch binding used an inline Nasal call `libraries.Sound.switch1();` which is not available in that binding scope, leading to the runtime error.

The fix is minimal and local:

in `Models/FlightDeck/a320.flightdeck.xml`, replace that single call with `setprop("sim/sound/switch1", 1);`

so the existing sound listener infrastructure (used by other two-position switches) handles the standard switch sound.
No other files were modified and surrounding XML was left intact.
