### PR TITLE
Fix correct transponder property path in atc.nas

### DIFF
--- a/Nasal/Panels/atc.nas
+++ b/Nasal/Panels/atc.nas
@@ -20,7 +20,7 @@ var Transponder = {
 	activeADIRS: 1,
 	condition: 0,
 	failed: 0,
-	codeDigitsNodes: [props.globals.getNode("/instrumentation/transponder/inputs/digit[0]", 1), props.globals.getNode("/instrumentation/transponder/inputs/digit[1]", 1), props.globals.getNode("/instrumentation/transponder/inputs/digit[2]", 1), props.globals.getNode("instrumentation/transponder/inputs/digit[3]", 1)],
+	codeDigitsNodes: [props.globals.getNode("/instrumentation/transponder/inputs/digit[0]", 1), props.globals.getNode("/instrumentation/transponder/inputs/digit[1]", 1), props.globals.getNode("/instrumentation/transponder/inputs/digit[2]", 1), props.globals.getNode("/instrumentation/transponder/inputs/digit[3]", 1)],
 	serviceableNode: props.globals.getNode("/instrumentation/transponder/serviceable", 1),
 	knobNode: props.globals.getNode("/instrumentation/transponder/inputs/knob-mode", 1),
 	identNode: props.globals.getNode("/instrumentation/transponder/inputs/ident-btn", 1),


### PR DESCRIPTION
**Describe the bug**
In `Nasal/Panels/atc.nas`, `Transponder.codeDigitsNodes` initializes one of the digit nodes using a relative property path without the leading `/`:
`instrumentation/transponder/inputs/digit[3]`.
The other entries in the same list use absolute paths (with a leading `/`), so this single inconsistent path can resolve to a different node in the property tree.

**To Reproduce**
Not provided. The issue was identified during code inspection; no user-visible reproduction steps are known.

**Expected behaviour**
All transponder digit nodes should be looked up using the canonical absolute property paths under `/instrumentation/transponder/inputs/digit[*]`.

**Screenshots**
No screenshots provided.

**System (please complete the following information):**
 - OS: Windows 11
 - FlightGear version: 2024.1
 - A320 Version: revision 2507

**Additional context**
The change is minimal and local: it only adds the missing leading `/` for the `digit[3]` `getNode()` path inside `codeDigitsNodes` in `Nasal/Panels/atc.nas`.
Only this single line was modified (1 insertion, 1 deletion). No other files were changed and no whitespace-only edits were made.