### PR TITLE
Fix allow fuel xfeed when opposite-side feed is unavailable

### DIFF
--- a/Systems/a320-fuel.xml
+++ b/Systems/a320-fuel.xml
@@ -608,7 +608,10 @@
 				</test>
 				/systems/fuel/feed-right-inner eq 1
 				/systems/fuel/valves/crossfeed-valve eq 1
-				/consumables/fuel/tank[1]/level-gal_us le /consumables/fuel/tank[3]/unusable-gal_us 
+				<test logic="OR">
+					/systems/fuel/feed-left-inner eq 0
+					/consumables/fuel/tank[1]/level-gal_us le /consumables/fuel/tank[1]/unusable-gal_us 
+				</test>
 				/consumables/fuel/tank[3]/level-gal_us gt /consumables/fuel/tank[3]/unusable-gal_us 
 				propulsion/tank[5]/contents-lbs lt 9
 			</test>
@@ -624,7 +627,10 @@
 				/systems/fuel/feed-left-inner eq 1
 				/systems/fuel/valves/crossfeed-valve eq 1
 				/consumables/fuel/tank[1]/level-gal_us gt /consumables/fuel/tank[1]/unusable-gal_us 
-				/consumables/fuel/tank[3]/level-gal_us le /consumables/fuel/tank[3]/unusable-gal_us 
+				<test logic="OR">
+					/systems/fuel/feed-right-inner eq 0
+					/consumables/fuel/tank[3]/level-gal_us le /consumables/fuel/tank[3]/unusable-gal_us 
+				</test>
 				propulsion/tank[6]/contents-lbs lt 9
 			</test>
 		</switch>


### PR DESCRIPTION
Hey folks — this is a small, local fix in the A320 fuel system to make X FEED behave as a practical balancing tool (without waiting for a tank to run down to unusable).

**Describe the bug**
In `Systems/a320-fuel.xml`, the wing→engine crossfeed selector gating relied on an “other tank empty / unusable” condition, which effectively prevented using X FEED for normal fuel balancing based on feed availability.

**To Reproduce**
Steps to reproduce the behaviour:
1. Start the A320 and run both engines.
2. Create a left/right fuel imbalance (e.g., different inner wing quantities).
3. Set X FEED to ON.
4. Turn OFF the pump switches on the lighter side (so that side’s feed becomes unavailable).
5. Observe that balancing does not start as expected unless the relevant tank reaches unusable conditions.

**Expected behaviour**
With X FEED ON, balancing should be possible as soon as the opposite-side feed is unavailable (pumps off / no feed), without requiring the “other tank empty / unusable” condition. The “own tank empty” check should remain as a fallback.

**Screenshots**
No screenshots provided.

**System**
- OS: Windows 11
- FlightGear version: 2024.1
- A320 Version: revision 2507

**Additional context**
The change is minimal and local (single file only):

- `Systems/a320-fuel.xml`: adjust wing→engine crossfeed selector gating to use `feed-left-inner` / `feed-right-inner == 0` as the primary condition (feed availability), while keeping the existing “own tank empty (unusable)” check as a fallback.

No other files were modified.
