### PR TITLE
Displays: Fix #350 ECAM Freeze by reverting lastMode to 3 where applicable

### DIFF
--- a/Nasal/ECAM/SystemDisplay.nas
+++ b/Nasal/ECAM/SystemDisplay.nas
@@ -283,6 +283,8 @@ var SystemDisplayController = {
 				if (me.mode == 1) {
 					me.lastDisplayedPage = me.displayedPage;
 					me.lastMode = me.mode;
+				} elsif (me.mode == 3) {
+    				me.lastMode = 3;
 				}
 				me.displayedPage = me.PageList[newPage];
 				me.mode = 0;
@@ -296,9 +298,11 @@ var SystemDisplayController = {
 					ECAMControlPanel.lightOn(me.displayedPage.name);
 					me.lastDisplayedPage = nil;
 					me.mode = 0;
+					me.lastMode = 3;
 				} else {
 					ECAMControlPanel.lightOff(me.displayedPage.name);
 					me.displayedPage = me.autoCall();
+					me.lastMode = 3;
 				}
 			} elsif (me.mode == 0) {
 				if (me.lastMode == 1) {
@@ -307,9 +311,11 @@ var SystemDisplayController = {
 					ECAMControlPanel.lightOn(me.displayedPage.name);
 					me.lastDisplayedPage = nil;
 					me.mode = 1;
+					me.lastMode = 3;
 				} else {
 					ECAMControlPanel.lightOff(me.displayedPage.name);
 					me.displayedPage = me.autoCall();
+					me.lastMode = 3;
 				}
 			}
 		} else {


### PR DESCRIPTION
### Description of Changes
Previously, pressing "CLR" and switching pages after a transient ECAM fault in the right ways could cause unintended persistence of the lastMode attribute (especially when it was set to '1'), in ways that didn't really mean anything or make sense. 

The persistence of lastMode attribute would cause the current displayed page to become nil, and subsequently freeze the ECAM completely when a nil object was referenced when hitting CLR again. This PR prevents all of that that. 

I do not have a concrete source to verify that the real aircraft works in the same way, but I'm pretty sure they don't really maintain a "browsing history" of the ECAM Pages (it sounds a little absurd, but I am not a pilot), so I think these changes do make sense.

### Bugs fixed (if any)
Fixes #350 

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
