### PR TITLE
METAR/TAF/ATIS WX request fix and parsing optimization

### DIFF
--- a/Nasal/Systems/Comm/Notification.nas
+++ b/Nasal/Systems/Comm/Notification.nas
@@ -1,8 +1,10 @@
 # A3XX Notification System
 # Jonathan Redpath
 
-# Copyright (c) 2026 Josh Davidson (Octal450)
-var defaultServer = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&mostRecent=true&hoursBeforeNow=12&stationString=";
+# Copyright (c) 2025 Josh Davidson (Octal450)
+#var defaultServer = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&mostRecent=true&hoursBeforeNow=12&stationString=";
+var defaultServer = "https://aviationweather.gov/api/data/metar?format=xml&taf=false&ids=";
+
 var result = nil;
 
 var ATSU = {
@@ -169,7 +171,8 @@ var AOC = {
 		
 		var serverString = "";
 		if (me.server.getValue() == "vatsim") {
-			serverString = "https://api.flybywiresim.com/metar/" ~ airport ~ "?source=vatsim";
+			#serverString = "https://api.flybywiresim.com/metar/" ~ airport ~ "?source=vatsim";
+			serverString = "https://metar.vatsim.net/" ~ airport ;
 		} else {
 			serverString = defaultServer ~ airport;
 		}
@@ -197,7 +200,8 @@ var AOC = {
 			me.sent = 0;
 			return 1;
 		}
-		http.load("https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=tafs&requestType=retrieve&format=xml&timeType=issue&mostRecent=true&hoursBeforeNow=12&stationString=" ~ airport)
+		#http.load("https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=tafs&requestType=retrieve&format=xml&timeType=issue&mostRecent=true&hoursBeforeNow=12&stationString=" ~ airport)
+		http.load("https://aviationweather.gov/api/data/taf?format=xml&taf=false&time=issue&ids=" ~ airport)
 			.fail(func(r) me.downloadFail(i))
 			.done(func(r) {
 				var errs = [];
@@ -211,6 +215,7 @@ var AOC = {
 			});
 		return 0;
 	},
+	# Metar-Prozessieren
 	processMETAR: func(r, i) {
 		var raw = r.response;
 		if (find('"statusCode":404',raw) != -1) {
@@ -219,18 +224,9 @@ var AOC = {
 			mcdu.mcdu_message(i, "NO METAR AVAILABLE");
 			return;
 		}
-		
+
 		if (me.server.getValue() == "vatsim") {
-			if (find("metar", raw) != -1) {
-				raw = split('"metar":"', raw)[1];
-				raw = split('","source":"Vatsim"}', raw)[0];
-			} else {
-				me.received = 0;
-				me.sent = 0;
-				mcdu.mcdu_message(i, "BAD SERVER RESPONSE");
-				return;
-			}
-			me.lastMETAR = raw;
+			me.lastMETAR = ("METAR " ~ raw); # Add the missing "METAR" at the beginning of Vatsim API string
 		} else if (find("<raw_text>", raw) != -1) {
 			raw = split("<raw_text>", raw)[1];
 			raw = split("</raw_text>", raw)[0];
@@ -256,7 +252,11 @@ var AOC = {
 		if (find("<raw_text>", raw) != -1) {
 			raw = split("<raw_text>", raw)[1];
 			raw = split("</raw_text>", raw)[0];
-			me.lastTAF = raw;
+			if (find("<![CDATA[", raw) != -1) {
+				raw = split("<![CDATA[", raw)[1];
+				raw = split("]]>", raw)[0];
+				me.lastTAF = raw;
+			}
 		} else {
 			me.received = 0;
 			me.sent = 0;
@@ -264,6 +264,9 @@ var AOC = {
 			return;
 		}
 		me.lastTAF = raw;
+		print("raw =" ~ raw);
+		debug.dump(raw);
+
 		settimer(func() {
 			me.received = 1;
 			mcdu.mcdu_message(i, "WX UPLINK");
@@ -382,31 +385,55 @@ var ATIS = {
 		} else if (find("INFORMATION ", raw) != -1) {
 			code = split("INFORMATION ", raw)[1];
 			code = split(" ", code)[0];
+		} else if (find("info ", raw) != -1) {
+			code = split("info ", raw)[1];
+			code = split(" ", code)[0];
+		} else if (find(" METAR", raw) != -1) {
+			code = split(" METAR", raw)[0];
+			code = split(" ", code)[-1];
 		} else if  (find("ATIS ", raw) != -1) {
 			code = split("ATIS ", raw)[1];
-			code = split(" ", code)[0];
-		} else if  (find("info ", raw) != -1) {
-			code = split("info ", raw)[1];
 			code = split(" ", code)[0];
 		} else {
 			print("Failed to find a valid ATIS code for " ~ me.station);
 			debug.dump(raw);
 		}
-		
+
+		# Cleanup
+
 		if (find(".", code) != -1) {
 			code = split(".", code)[0];
 		}
-		
+
 		if (find(",", code) != -1) {
 			code = split(",", code)[0];
 		}
-		
-		if (size(code) > 1) {
-			code = left(code, 1);
+
+		# Sanity Check aginst allowed ATIS Code returns
+
+		# Fetch corresponding NATO codes for candidate from dictionary if present
+
+		var dictcode = atsu.DictionaryString.fetchString1(var scode = left(code, 1));
+
+		if ( dictcode != "" ) {
+			print("Wörterbuch gefunden");
+
+			if ((size(code) == 1)) {
+				print("Parsed ATIS string is valid single letter, information: " ~ code );
+				me.receivedCode = code;
+			} else if (dictcode.string2 == code) {
+				print ("Parsed long string is valid ATIS code " ~ code );
+				me.receivedCode = scode ;
+			} else {
+				print("ATIS Code is not in dictionary");
+				debug.dump(raw);
+			}
+
+		} else {
+			print("Failed to find a valid ATIS code for "  ~ me.station);
+			debug.dump(raw);
 		}
-		
-		me.receivedCode = code;
-		
+
 		var time = "";
 		if (find("Time ", raw) != -1) {
 			time = split("Time ", raw)[1];
@@ -441,6 +468,9 @@ var ATIS = {
 		} else if (find("INFORMATION " ~ code ~ " AT ", raw) != -1) {
 			time = split("INFORMATION " ~ code ~ " AT ", raw)[1];
 			time = left(time, 4);
+		} else if (find("METAR ", raw) != -1) {
+			time = split("METAR ", raw)[1];
+			time = substr(time, 2, 4);
 		} else if (find((code ~ " "), raw) != -1) {
 			if (size(split(" ",split(code ~ " ", raw)[1])[0]) == 4) {
 				time = split(" ",split(code ~ " ", raw)[1])[0];

--- a/Nasal/Systems/Comm/Notification.nas
+++ b/Nasal/Systems/Comm/Notification.nas
@@ -4,7 +4,6 @@
 # Copyright (c) 2025 Josh Davidson (Octal450)
 
 var defaultServer = "https://aviationweather.gov/api/data/metar?format=xml&taf=false&ids=";
-
 var result = nil;
 
 var ATSU = {
@@ -180,7 +179,7 @@ var AOC = {
 			.fail(func(r) me.downloadFail(i, r))
 			.done(func(r) {
 				var errs = [];
-				call(me.processMETAR, [r, i], me, {}, errs); 
+				call(me.processMETAR, [r, i, airport], me, {}, errs);
 				if (size(errs) > 0) {
 					print("Failed to parse METAR for " ~ airport);
 					debug.dump(r.response);
@@ -213,9 +212,9 @@ var AOC = {
 			});
 		return 0;
 	},
-
-	processMETAR: func(r, i) {
+	processMETAR: func(r, i, airport) {
 		var raw = r.response;
+
 		if (find('"statusCode":404',raw) != -1) {
 			me.received = 0;
 			me.sent = 0;
@@ -224,7 +223,15 @@ var AOC = {
 		}
 
 		if (me.server.getValue() == "vatsim") {
-			me.lastMETAR = ("METAR " ~ raw); # Add the missing "METAR" at the beginning of Vatsim API string
+			if (find(airport,raw) != -1) {
+				me.lastMETAR = ("METAR " ~ raw); # Add the missing "METAR" at the beginning of Vatsim API string
+			}
+			else {
+				me.received = 0;
+				me.sent = 0;
+				mcdu.mcdu_message(i, "BAD SERVER RESPONSE");
+				return;
+			}
 		} else if (find("<raw_text>", raw) != -1) {
 			raw = split("<raw_text>", raw)[1];
 			raw = split("</raw_text>", raw)[0];

--- a/Nasal/Systems/Comm/Notification.nas
+++ b/Nasal/Systems/Comm/Notification.nas
@@ -2,7 +2,7 @@
 # Jonathan Redpath
 
 # Copyright (c) 2025 Josh Davidson (Octal450)
-#var defaultServer = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&mostRecent=true&hoursBeforeNow=12&stationString=";
+
 var defaultServer = "https://aviationweather.gov/api/data/metar?format=xml&taf=false&ids=";
 
 var result = nil;
@@ -171,7 +171,6 @@ var AOC = {
 		
 		var serverString = "";
 		if (me.server.getValue() == "vatsim") {
-			#serverString = "https://api.flybywiresim.com/metar/" ~ airport ~ "?source=vatsim";
 			serverString = "https://metar.vatsim.net/" ~ airport ;
 		} else {
 			serverString = defaultServer ~ airport;
@@ -200,7 +199,6 @@ var AOC = {
 			me.sent = 0;
 			return 1;
 		}
-		#http.load("https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=tafs&requestType=retrieve&format=xml&timeType=issue&mostRecent=true&hoursBeforeNow=12&stationString=" ~ airport)
 		http.load("https://aviationweather.gov/api/data/taf?format=xml&taf=false&time=issue&ids=" ~ airport)
 			.fail(func(r) me.downloadFail(i))
 			.done(func(r) {
@@ -215,7 +213,7 @@ var AOC = {
 			});
 		return 0;
 	},
-	# Metar-Prozessieren
+
 	processMETAR: func(r, i) {
 		var raw = r.response;
 		if (find('"statusCode":404',raw) != -1) {
@@ -264,8 +262,6 @@ var AOC = {
 			return;
 		}
 		me.lastTAF = raw;
-		print("raw =" ~ raw);
-		debug.dump(raw);
 
 		settimer(func() {
 			me.received = 1;
@@ -374,7 +370,6 @@ var ATIS = {
 				raw = split('"}', raw)[0];
 			}
 		}
-		
 		var code = "";
 		if (find("INFO ", raw) != -1) {
 			code = split("INFO ", raw)[1];
@@ -410,14 +405,11 @@ var ATIS = {
 		}
 
 		# Sanity Check aginst allowed ATIS Code returns
-
 		# Fetch corresponding NATO codes for candidate from dictionary if present
 
 		var dictcode = atsu.DictionaryString.fetchString1(var scode = left(code, 1));
 
 		if ( dictcode != "" ) {
-			print("Wörterbuch gefunden");
-
 			if ((size(code) == 1)) {
 				print("Parsed ATIS string is valid single letter, information: " ~ code );
 				me.receivedCode = code;
@@ -428,7 +420,6 @@ var ATIS = {
 				print("ATIS Code is not in dictionary");
 				debug.dump(raw);
 			}
-
 		} else {
 			print("Failed to find a valid ATIS code for "  ~ me.station);
 			debug.dump(raw);

--- a/Nasal/Systems/Comm/Notification.nas
+++ b/Nasal/Systems/Comm/Notification.nas
@@ -1,7 +1,7 @@
 # A3XX Notification System
 # Jonathan Redpath
 
-# Copyright (c) 2025 Josh Davidson (Octal450)
+# Copyright (c) 2026 Josh Davidson (Octal450)
 
 var defaultServer = "https://aviationweather.gov/api/data/metar?format=xml&taf=false&ids=";
 var result = nil;
@@ -214,14 +214,12 @@ var AOC = {
 	},
 	processMETAR: func(r, i, airport) {
 		var raw = r.response;
-
 		if (find('"statusCode":404',raw) != -1) {
 			me.received = 0;
 			me.sent = 0;
 			mcdu.mcdu_message(i, "NO METAR AVAILABLE");
 			return;
 		}
-
 		if (me.server.getValue() == "vatsim") {
 			if (find(airport,raw) != -1) {
 				me.lastMETAR = ("METAR " ~ raw); # Add the missing "METAR" at the beginning of Vatsim API string
@@ -414,15 +412,14 @@ var ATIS = {
 		# Sanity Check aginst allowed ATIS Code returns
 		# Fetch corresponding NATO codes for candidate from dictionary if present
 
-		var dictcode = atsu.DictionaryString.fetchString1(var scode = left(code, 1));
-
-		if ( dictcode != "" ) {
+		var dictCode = atsu.DictionaryString.fetchString1(var sCode = left(code, 1));
+		if ( dictCode != "" ) {
 			if ((size(code) == 1)) {
 				print("Parsed ATIS string is valid single letter, information: " ~ code );
 				me.receivedCode = code;
-			} else if (dictcode.string2 == code) {
+			} else if (dictCode.string2 == code) {
 				print ("Parsed long string is valid ATIS code " ~ code );
-				me.receivedCode = scode ;
+				me.receivedCode = sCode ;
 			} else {
 				print("ATIS Code is not in dictionary");
 				debug.dump(raw);


### PR DESCRIPTION
METAR/TAF/ATIS WX request fix and parsing optimization

### Description of Changes

API links for METAR/TAF requests have been updated to restore WX request. #366 
METAR now comes from VATSIM directly (if selected) and is a simple string opposed to JSON. 
TAF data soruce is now XML.

Parsing logic for ATIS (ATIS code/time detection) has been slightly optimized to overcome erroneous parsing cases.

1) A new conditional searches for the key string " METAR", which is a very common occurence in VATSIM ATISs.
2) A "sanity check" has been added to see if the parsed ATIS code candidate is either a single letter or a valid "NATO"-code. The implemented global dictionary is being used for this.
3) ATIS "time" detection has been slightly altered to overcome edge cases. 

The fix doesn't implement new features, but restores functionality and increases parsing precision through new conditions and result checking.

Only Notification.nas has been edited.

### Screenshots (optional)

### Bugs fixed (if any)

Loss of Weather request capabilities via the MCDU/AOC https://github.com/legoboyvdlp/A320-family/issues/366

Common ATIS formats that produced erroneous ATIS code parsing are now accounted for.


### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
