### PR TITLE
Prevent PFD and ND Switching to TRK on Compass in TRK/FPA mode

### DIFF
--- a/Models/Instruments/ND/canvas/framework/navdisplay.nas
+++ b/Models/Instruments/ND/canvas/framework/navdisplay.nas
@@ -721,7 +721,7 @@ canvas.NavDisplay.update = func() # FIXME: This stuff is still too aircraft spec
 		me.symbols.selHdgLine2.hide();
 		me.symbols.curHdgPtr.setVisible(staPtrVis);
 		me.symbols.HdgBugCRT.setVisible(staPtrVis and !dispLCD);
-		if (me.get_switch("toggle_track_heading")) {
+		if (getprop("/it-autoflight/custom/trk-fpa")) {
 			me.symbols.HdgBugLCD.hide();
 			if (hdg_bug_active) {
 				me.symbols.TrkBugLCD.setVisible(staPtrVis and dispLCD);
@@ -773,7 +773,7 @@ canvas.NavDisplay.update = func() # FIXME: This stuff is still too aircraft spec
 		me.symbols.selHdgLine.hide();
 		me.symbols.curHdgPtr2.setVisible(staPtrVis);
 		me.symbols.HdgBugCRT2.setVisible(staPtrVis and !dispLCD);
-		if (me.get_switch("toggle_track_heading")) {
+		if (getprop("/it-autoflight/custom/trk-fpa")) {
 			me.symbols.HdgBugLCD2.hide();
 			if (hdg_bug_active) {
 				me.symbols.TrkBugLCD2.setVisible(staPtrVis and dispLCD);

--- a/Nasal/FMGC/FMGC-b.nas
+++ b/Nasal/FMGC/FMGC-b.nas
@@ -938,8 +938,9 @@ var ITAF = {
 			Input.vert.setValue(5); # This way we only do this if all conditions are true
 		}
 		Input.trk.setBoolValue(1);
-		Custom.ndTrkSel[0].setBoolValue(1);
-		Custom.ndTrkSel[1].setBoolValue(1);
+		# Forces HDG UP even in TRK/FPA.
+		Custom.ndTrkSel[0].setBoolValue(0);
+		Custom.ndTrkSel[1].setBoolValue(0);
 		Input.hdgCalc = Input.hdg.getValue() + math.round(Internal.driftAngle.getValue());
 		if (Input.hdgCalc > 360) { # It's rounded, so this is ok. Otherwise do >= 360.5
 			Input.hdgCalc = Input.hdgCalc - 360;

--- a/Systems/pfd.xml
+++ b/Systems/pfd.xml
@@ -63,12 +63,6 @@
 		<name>Heading scale</name>
 		<type>gain</type>
 		<gain>1.0</gain>
-		<input>
-			<condition>
-				<property>/it-autoflight/custom/trk-fpa</property>
-			</condition>
-			<property>/instrumentation/pfd/track-deg</property>
-		</input>
 		<input>/instrumentation/pfd/heading-deg</input>
 		<output>/instrumentation/pfd/heading-scale</output>
 	</filter>


### PR DESCRIPTION
### Description of Changes
This PR Prevents the Primary Flight Display and the Navigation Displays displaying the aircraft's Track in the compass ROSE in TRK/FPA mode instead of the headings. The PFD must always show the magnetic/true heading at the bottom. The track is instead indicated by the green diamond.

As for the ND, as far as I can tell from resources online, the fixed aircraft symbol and the compass ROSE **always** displays heading pointing UP at all times. The Track is instead indicated by a green diamond. 

### Bugs fixed (if any)

N/A No bugs filed on the github page for this as far as I am aware

### Tests with these Changes & the results :

**PFD:**
- Autopilot follows selected heading and track correctly.
- Compass at the bottom no longer jumps suddenly when switching to TRK/FPA.
- Blue HDG/TRK selection bug moves correctly on the compass at the bottom depending on selected mode.

**ND:**
- Track and Heading displayed correctly
- VOR/ADF markers correctly display the magnetic heading of VOR/ADF beacons w.r..t the fixed aircraft symbol (in all modes).
-  ILS/VOR ROSE Modes also show indicators correctly.
- In TRK/FPA the White Track Select bug appears correctly instead of the blue bug on the compass rose and the yellow heading indicator disappears (this was the previous behaviour)

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
