### PR TITLE
Fix managed mode FCU preview display for SPD knob

### DIFF
--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -1434,7 +1434,7 @@
 		<axis-alignment>xy-plane</axis-alignment>
 		<type type="string">number-value</type>
 		<format type="string">%3.0f</format>
-		<property>it-autoflight/input/kts</property>
+		<property>it-autoflight/input/kts-display</property>
 		<truncate>false</truncate>
 		<font type="string">Airbus7Seg.ttf</font>
 		<draw-text>true</draw-text>
@@ -1460,7 +1460,7 @@
 		<axis-alignment>xy-plane</axis-alignment>
 		<type type="string">number-value</type>
 		<format type="string">%0.3f</format>
-		<property>it-autoflight/input/mach</property>
+		<property>it-autoflight/input/mach-display</property>
 		<truncate>false</truncate>
 		<font type="string">Airbus7Seg.ttf</font>
 		<draw-text>true</draw-text>
@@ -2815,7 +2815,7 @@
 			<and>
 				<not><property>controls/switches/annun-test</property></not>
 				<not><property>it-autoflight/input/kts-mach</property></not>
-				<not><property>it-autoflight/input/spd-managed</property></not>
+				<property>it-autoflight/custom/show-spd</property>
 				<property>FMGC/FCU-working</property>
 			</and>
 		</condition>
@@ -2828,7 +2828,7 @@
 			<and>
 				<not><property>controls/switches/annun-test</property></not>
 				<property>it-autoflight/input/kts-mach</property>
-				<not><property>it-autoflight/input/spd-managed</property></not>
+				<property>it-autoflight/custom/show-spd</property>
 				<property>FMGC/FCU-working</property>
 			</and>
 		</condition>

--- a/Nasal/FMGC/FCU.nas
+++ b/Nasal/FMGC/FCU.nas
@@ -216,6 +216,8 @@ var FCUController = {
 			if (fmgc.FMGCInternal.crzSet and fmgc.FMGCInternal.costIndexSet) {
 				fmgc.Custom.Input.spdManaged.setBoolValue(1);
 				fmgc.ManagedSPD.start();
+				# Reset showSpd so dashes appear immediately
+				fmgc.Custom.showSpd.setBoolValue(0);
 			}
 		}
 	},
@@ -225,32 +227,88 @@ var FCUController = {
 		if (me.FCUworking) {
 			fmgc.Custom.Input.spdManaged.setBoolValue(0);
 			fmgc.ManagedSPD.stop();
-			me.ias = fmgc.Velocities.indicatedAirspeedKt.getValue();
-			me.mach = fmgc.Velocities.indicatedMach.getValue();
-			if (!fmgc.Input.ktsMach.getBoolValue()) {
-				if (me.ias >= 100 and me.ias <= 399) {
-					fmgc.Input.kts.setValue(math.round(me.ias));
-				} else if (me.ias < 100) {
-					fmgc.Input.kts.setValue(100);
-				} else if (me.ias > 399) {
-					fmgc.Input.kts.setValue(399);
+
+			# If user was previewing a value, use that; otherwise use current airspeed
+			if (fmgc.Custom.showSpd.getBoolValue()) {
+				# Use preview value that was dialed in
+				if (!fmgc.Input.ktsMach.getBoolValue()) {
+					fmgc.Input.kts.setValue(fmgc.Input.ktsPreview.getValue());
+				} else {
+					fmgc.Input.mach.setValue(fmgc.Input.machPreview.getValue());
 				}
-			} else if (fmgc.Input.ktsMach.getBoolValue()) {
-				if (me.mach >= 0.10 and me.mach <= 0.99) {
-					fmgc.Input.mach.setValue(math.round(me.mach, 0.001));
-				} else if (me.mach < 0.10) {
-					fmgc.Input.mach.setValue(0.10);
-				} else if (me.mach > 0.99) {
-					fmgc.Input.mach.setValue(0.99);
+			} else {
+				# Use current indicated airspeed
+				me.ias = fmgc.Velocities.indicatedAirspeedKt.getValue();
+				me.mach = fmgc.Velocities.indicatedMach.getValue();
+				if (!fmgc.Input.ktsMach.getBoolValue()) {
+					if (me.ias >= 100 and me.ias <= 399) {
+						fmgc.Input.kts.setValue(math.round(me.ias));
+					} else if (me.ias < 100) {
+						fmgc.Input.kts.setValue(100);
+					} else if (me.ias > 399) {
+						fmgc.Input.kts.setValue(399);
+					}
+				} else if (fmgc.Input.ktsMach.getBoolValue()) {
+					if (me.mach >= 0.10 and me.mach <= 0.99) {
+						fmgc.Input.mach.setValue(math.round(me.mach, 0.001));
+					} else if (me.mach < 0.10) {
+						fmgc.Input.mach.setValue(0.10);
+					} else if (me.mach > 0.99) {
+						fmgc.Input.mach.setValue(0.99);
+					}
 				}
 			}
+
+			# Switch to selected mode - show value (not dashes)
+			fmgc.Custom.showSpd.setBoolValue(1);
 		}
 	},
 	machTemp: nil,
 	iasTemp: nil,
 	SPDAdjust: func(d) {
 		if (me.FCUworking) {
-			if (!fmgc.Custom.Input.spdManaged.getBoolValue()) {
+			if (fmgc.Custom.Input.spdManaged.getBoolValue()) {
+				spdInput();
+				# In managed mode, adjust preview properties
+				if (fmgc.Input.ktsMach.getBoolValue()) {
+					me.machTemp = fmgc.Input.machPreview.getValue();
+					if (d == 1) {
+						me.machTemp = math.round(me.machTemp + 0.001, 0.001); # Kill floating point error
+					} else if (d == -1) {
+						me.machTemp = math.round(me.machTemp - 0.001, 0.001); # Kill floating point error
+					} else if (d == 10) {
+						me.machTemp = math.round(me.machTemp + 0.01, 0.01); # Kill floating point error
+					} else if (d == -10) {
+						me.machTemp = math.round(me.machTemp - 0.01, 0.01); # Kill floating point error
+					}
+					if (me.machTemp < 0.10) {
+						fmgc.Input.machPreview.setValue(0.10);
+					} else if (me.machTemp > 0.99) {
+						fmgc.Input.machPreview.setValue(0.99);
+					} else {
+						fmgc.Input.machPreview.setValue(me.machTemp);
+					}
+				} else {
+					me.iasTemp = fmgc.Input.ktsPreview.getValue();
+					if (d == 1) {
+						me.iasTemp = me.iasTemp + 1;
+					} else if (d == -1) {
+						me.iasTemp = me.iasTemp - 1;
+					} else if (d == 10) {
+						me.iasTemp = me.iasTemp + 10;
+					} else if (d == -10) {
+						me.iasTemp = me.iasTemp - 10;
+					}
+					if (me.iasTemp < 100) {
+						fmgc.Input.ktsPreview.setValue(100);
+					} else if (me.iasTemp > 399) {
+						fmgc.Input.ktsPreview.setValue(399);
+					} else {
+						fmgc.Input.ktsPreview.setValue(me.iasTemp);
+					}
+				}
+			} else {
+				# In selected mode, adjust actual properties
 				if (fmgc.Input.ktsMach.getBoolValue()) {
 					me.machTemp = fmgc.Input.mach.getValue();
 					if (d == 1) {
@@ -563,5 +621,13 @@ var hdgInput = func {
 	if (fmgc.Output.lat.getValue() != 0) {
 		fmgc.Custom.showHdg.setBoolValue(1);
 		fmgc.Custom.hdgTime = pts.Sim.Time.elapsedSec.getValue();
+	}
+}
+
+# If the speed knob is turned while in managed mode, it will display speed for a period of time
+var spdInput = func {
+	if (fmgc.Custom.Input.spdManaged.getBoolValue()) {
+		fmgc.Custom.showSpd.setBoolValue(1);
+		fmgc.Custom.spdTime = pts.Sim.Time.elapsedSec.getValue();
 	}
 }

--- a/Nasal/FMGC/FMGC-b.nas
+++ b/Nasal/FMGC/FMGC-b.nas
@@ -103,10 +103,12 @@ var Input = {
 	hdg: props.globals.initNode("/it-autoflight/input/hdg", 0, "INT"),
 	hdgCalc: 0,
 	kts: props.globals.initNode("/it-autoflight/input/kts", 100, "INT"),
+	ktsPreview: props.globals.initNode("/it-autoflight/input/kts-preview", 100, "INT"),
 	ktsMach: props.globals.initNode("/it-autoflight/input/kts-mach", 0, "BOOL"),
 	lat: props.globals.initNode("/it-autoflight/input/lat", 5, "INT"),
 	latTemp: 5,
 	mach: props.globals.initNode("/it-autoflight/input/mach", 0.5, "DOUBLE"),
+	machPreview: props.globals.initNode("/it-autoflight/input/mach-preview", 0.5, "DOUBLE"),
 	toga: props.globals.initNode("/it-autoflight/input/toga", 0, "BOOL"),
 	trk: props.globals.initNode("/it-autoflight/input/trk", 0, "BOOL"),
 	trueCourse: props.globals.initNode("/it-autoflight/input/true-course", 0, "BOOL"),
@@ -185,8 +187,10 @@ var Sound = {
 var Custom = {
 	apFdOn: 0,
 	hdgTime: -45,
+	spdTime: -10,
 	ndTrkSel: [props.globals.getNode("/instrumentation/efis[0]/trk-selected", 1), props.globals.getNode("/instrumentation/efis[1]/trk-selected", 1)],
 	showHdg: props.globals.initNode("/it-autoflight/custom/show-hdg", 1, "BOOL"),
+	showSpd: props.globals.initNode("/it-autoflight/custom/show-spd", 1, "BOOL"),
 	trkFpa: props.globals.initNode("/it-autoflight/custom/trk-fpa", 0, "BOOL"),
 	Input: {
 		spdManaged: props.globals.getNode("/it-autoflight/input/spd-managed", 1),
@@ -249,6 +253,7 @@ var ITAF = {
 		me.updateLatText("");
 		me.updateVertText("");
 		Custom.showHdg.setBoolValue(1);
+		Custom.showSpd.setBoolValue(1);
 		Custom.Output.fmaPower = 1;
 		
 		# Sync FMA
@@ -406,6 +411,15 @@ var ITAF = {
 				Custom.showHdg.setBoolValue(1);
 			} else {
 				Custom.showHdg.setBoolValue(0);
+			}
+		}
+
+		# Preselect Speed
+		if (Custom.Input.spdManaged.getBoolValue()) { # In managed speed mode
+			if (Custom.spdTime + 10 >= Misc.elapsedSec.getValue()) {
+				Custom.showSpd.setBoolValue(1);
+			} else {
+				Custom.showSpd.setBoolValue(0);
 			}
 		}
 	},

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -1043,11 +1043,20 @@ var ManagedSPD = maketimer(0.25, func {
 				Input.ktsMach.setValue(1);
 			}
 			
-			# Set target speed
+			# Always set target speed for autothrottle (actual properties)
 			if (Input.kts.getValue() != FMGCInternal.mngSpd and !ktsmach) {
 				Input.kts.setValue(FMGCInternal.mngSpd);
 			} elsif (Input.mach.getValue() != FMGCInternal.mngSpd and ktsmach) {
 				Input.mach.setValue(FMGCInternal.mngSpd);
+			}
+
+			# Update preview properties to track the managed target (only when not actively adjusting the knob)
+			if (!Custom.showSpd.getBoolValue()) {
+				if (Input.ktsPreview.getValue() != FMGCInternal.mngSpd and !ktsmach) {
+					Input.ktsPreview.setValue(FMGCInternal.mngSpd);
+				} elsif (Input.machPreview.getValue() != FMGCInternal.mngSpd and ktsmach) {
+					Input.machPreview.setValue(FMGCInternal.mngSpd);
+				}
 			}
 		} else {
 			ManagedSPD.stop();

--- a/Systems/a320-indicators.xml
+++ b/Systems/a320-indicators.xml
@@ -1567,7 +1567,7 @@
 		<switch name="/controls/indicators/fcu-spd-dash">
 			<default value="0"/>
 			<test logic="AND" value="1">
-				/it-autoflight/input/spd-managed eq 1
+				/it-autoflight/custom/show-spd ne 1
 				/controls/switches/annun-test ne 1
 				/systems/electrical/bus/ac-ess-shed ge 110
 			</test>
@@ -1581,6 +1581,27 @@
 					/controls/switches/annun-test eq 1
 				</test>
 				/systems/electrical/bus/ac-ess-shed ge 110
+			</test>
+		</switch>
+
+		<!-- Speed display properties: show preview when managed, otherwise show actual -->
+		<switch name="/it-autoflight/input/kts-display">
+			<default value="0"/>
+			<test value="/it-autoflight/input/kts-preview">
+				/it-autoflight/input/spd-managed eq 1
+			</test>
+			<test value="/it-autoflight/input/kts">
+				/it-autoflight/input/spd-managed ne 1
+			</test>
+		</switch>
+
+		<switch name="/it-autoflight/input/mach-display">
+			<default value="0"/>
+			<test value="/it-autoflight/input/mach-preview">
+				/it-autoflight/input/spd-managed eq 1
+			</test>
+			<test value="/it-autoflight/input/mach">
+				/it-autoflight/input/spd-managed ne 1
 			</test>
 		</switch>
 


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
Implements the FCOM-specified behavior (DSC-22_10-40-20) where turning the SPD knob in managed mode temporarily displays a dialed-in value before reverting to dashes.

**In managed speed mode:**
- SPD window displays dashes with managed dot lit
- Turning the knob (without pulling) displays the dialed-in value
- Managed dot remains lit while preview is shown
- Autothrottle continues using managed target (preview does not affect guidance)
- After 10 seconds of inactivity, dashes reappear
- Pulling the knob switches to selected mode using the previewed value

**In selected speed mode (not changed):**
- SPD window displays the selected target value
- Turning the knob updates the displayed value immediately
- No timeout behavior

**New properties:**
- /it-autoflight/custom/show-spd - Controls value vs. dashes display (just like show-hdg boolean)
- /it-autoflight/input/kts-preview - Preview IAS value (managed mode only)
- /it-autoflight/input/mach-preview - Preview Mach value (managed mode only)
- /it-autoflight/input/kts-display - Displayed value (preview in managed, actual in selected)
- /it-autoflight/input/mach-display - Displayed value (preview in managed, actual in selected)

**Testing:**

I tested all the permutations of the different modes and states as spelled out above. It works correctly for both SPD/MACH modes and with proper transitions switching between managed/selected mode.

I dropped the following script under my `$HOME/.fgfs/Nasal/` directory to help during debugging and testing:

```javascript
var showBobProps = func {
    var display = screen.display.new(10, 10);
    display.add("/it-autoflight/input/kts");
    display.add("/it-autoflight/input/kts-display");
    display.add("/it-autoflight/input/kts-preview");
    display.add("/it-autoflight/input/mach");
    display.add("/it-autoflight/input/mach-display");
    display.add("/it-autoflight/input/mach-preview");
    display.add("/it-autoflight/custom/show-spd");
    display.add("/it-autoflight/input/kts-mach");
    display.add("/it-autoflight/input/spd-managed");
}
showBobProps();
```

**Notes:**

I observed one little issue where in managed mode with MACH set, the preview digits overlap visually with the "managed dot" in the SPD window like this: 

<img width="271" height="135" alt="image" src="https://github.com/user-attachments/assets/bce87dbc-e5ab-4e6e-869f-8a86c6c5b25a" />

In SPD mode, there is no overlap because knots is only three digits.

Looks like this could be fixed in `fd_complete.ac`, but not sure how you guys edit that file, so I left it as is. Maybe another way would be to move the dot slightly to the right with a translate animation in the `a320.flightdeck.xml` file. Let me know if you want me to try that way?

This is my first time working on FlightGear code, so kindly review with extra care. Happy to take any feedback and learn if this can be done better.

### Bugs fixed (if any)
Fixes #394

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
