### PR TITLE
change default livery to Lufthansa due to Spirit's shutdown

### DIFF
--- a/A320neo-PW-set.xml
+++ b/A320neo-PW-set.xml
@@ -16,7 +16,6 @@
 				<file>DLH</file>
 				<texture-fuselage>DLH-fuselage.png</texture-fuselage>
 				<texture-engine>PW1127-white.png</texture-engine>
-				<texture-placards>Fuselage/res/placards.png</texture-placards>
 			</livery>
 			<livery-dir type="string">Aircraft/A320-family/Models/Liveries/PW-NEO</livery-dir>
 		</model>

--- a/A320neo-PW-set.xml
+++ b/A320neo-PW-set.xml
@@ -13,9 +13,10 @@
 		<model>
 			<path>Aircraft/A320-family/Models/A320neo-PW.xml</path>
 			<livery>
-				<file>NKS</file>
-				<texture-fuselage>NKS-fuselage.png</texture-fuselage>
-				<texture-engine>NKS-engine.png</texture-engine>
+				<file>DLH</file>
+				<texture-fuselage>DLH-fuselage.png</texture-fuselage>
+				<texture-engine>PW1127-white.png</texture-engine>
+				<texture-placards>Fuselage/res/placards.png</texture-placards>
 			</livery>
 			<livery-dir type="string">Aircraft/A320-family/Models/Liveries/PW-NEO</livery-dir>
 		</model>


### PR DESCRIPTION
I changed the default livery of A320neo PW from Spirit Airlines to Lufthansa since Spirit Airlines has ceased operations.