### PR TITLE
Waypoints: fixes #407 and allows for 20 wpts

### DIFF
--- a/Nasal/FMGC/flightplan-waypoints.nas
+++ b/Nasal/FMGC/flightplan-waypoints.nas
@@ -191,15 +191,15 @@ var WaypointDatabase = {
 			if (childNode == nil) { 
 				continue; 
 			}
-			
-			var wpt = createWP({lat: num(childNode.getChild("latitude").getValue()), lon: num(childNode.getChild("longitude").getValue())},childNode.getChild("ident").getValue());
-			
-			if (left(childNode.getChild("ident").getValue(), 3) == "PBD") {
-				pilotWP = pilotWaypoint.newAtPosition(wpt, "PBD", right(childNode.getChild("ident").getValue(), 1));
+            var ident = childNode.getChild("ident").getValue();
+            var indexer = string.replace(ident,string.trim(ident,1, string.isdigit),"");
+			var wpt = createWP({lat: num(childNode.getChild("latitude").getValue()), lon: num(childNode.getChild("longitude").getValue())},ident);
+			if (left(ident, 3) == "PBD") {
+				pilotWP = pilotWaypoint.newAtPosition(wpt, "PBD", indexer);
 			} else {
-				pilotWP = pilotWaypoint.newAtPosition(wpt, "LL", right(childNode.getChild("ident").getValue(), 1));
+				pilotWP = pilotWaypoint.newAtPosition(wpt, "LL", indexer);
 			}
-			me.addWPToPos(pilotWP, right(childNode.getChild("ident").getValue(), 1));
+			me.addWPToPos(pilotWP, indexer);
 		}
 	},
 	# addWPToPos - helper for reading - inserts at specific index
@@ -225,7 +225,6 @@ var pilotWaypoint = {
 		# Figure out what the first index is we can use
 		var nilIndex = WaypointDatabase.getNilIndex();
 		var position = nil;
-		
 		if (nilIndex == -1) {
 			position = WaypointDatabase.getSize() + 1;
 		} else {

--- a/Nasal/MCDU/MCDU.nas
+++ b/Nasal/MCDU/MCDU.nas
@@ -1306,6 +1306,7 @@ var rskbutton = func(btn, i) {
 				if (fmgc.WaypointDatabase.confirm[i]) {
 					fmgc.WaypointDatabase.confirm[i] = 0;
 					canvas_mcdu.myPilotWP[i].deleteCmd();
+					pageNode[i].setValue("DATA2");
 				} else {
 					fmgc.WaypointDatabase.confirm[i] = 1;
 					canvas_mcdu.myPilotWP[i].deleteCmd();

--- a/Nasal/MCDU/PILOTWAYPOINT.nas
+++ b/Nasal/MCDU/PILOTWAYPOINT.nas
@@ -88,9 +88,9 @@ var pilotWaypointPage = {
 	deleteCmd: func() {
 		if (!fmgc.WaypointDatabase.confirm[me.computer]) {
 			fmgc.WaypointDatabase.delete(me.computer);
-			me.scroll = fmgc.WaypointDatabase.getNonNilIndex();
+		} else {
+			me._setupPageWithData();
+			canvas_mcdu.pageSwitch[me.computer].setBoolValue(0);
 		}
-		me._setupPageWithData();
-		canvas_mcdu.pageSwitch[me.computer].setBoolValue(0);
 	},
 };


### PR DESCRIPTION
### Description of Changes

Use last numeric digits of waypoint name instead of the last digit.

### Screenshots (optional)

### Bugs fixed (if any)

#407 
Allows for saving and loading more than 9 waypoints now.

Does not fix handling of `PBD0` but should prevent it's creation.

You will have to delete waypoints when you get to the previous hard-coded limit of 20 now. Other sims appear to allow 99.

The delete-all function throws a benign error after deleting them.
```
   90.74 [ALRT]:nasal      Nasal runtime error: While accessing member 'id': Type nil is not an object, it cannot have members
   90.74 [ALRT]:nasal        at /home/fgfs/.fgfs/Aircraft/A320-family/Nasal/MCDU/PILOTWAYPOINT.nas, line 35
   90.74 [ALRT]:nasal        called from: /home/fgfs/.fgfs/Aircraft/A320-family/Nasal/MCDU/PILOTWAYPOINT.nas, line 93
   90.74 [ALRT]:nasal        called from: /home/fgfs/.fgfs/Aircraft/A320-family/Nasal/MCDU/MCDU.nas, line 1308
```

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See Docs/CONTRIBUTING.md to verify. -->
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
