### PR TITLE
Fix multiplayer nose light state

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -5175,3 +5175,4 @@
 	</maintainance>
 
 </PropertyList>
+

--- a/A320-main.xml
+++ b/A320-main.xml
@@ -574,6 +574,7 @@
 				<float n="7" alias="/systems/fcs/aileron-r/final-deg"/>
 				<float n="8" alias="/systems/fcs/rudder/final-deg"/>
 				<float n="9" alias="/systems/fcs/stabilizer/final-deg"/>
+				<float n="10" alias="/sim/model/lights/nose-lights"/>
 				<float n="11" alias="/fdm/jsbsim/fcs/slat-pos-norm"/>
 				<float n="12" alias="/fdm/jsbsim/fcs/flap-pos-norm"/>
 				<int n="2" alias="/controls/lighting/landing-lights[0]"/>

--- a/Models/A320-common.xml
+++ b/Models/A320-common.xml
@@ -927,3 +927,4 @@
 		</condition>
 	</animation>
 </PropertyList>
+

--- a/Models/A320-common.xml
+++ b/Models/A320-common.xml
@@ -911,12 +911,14 @@
 		<object-name>Second Nosegear landing light ALS</object-name>
 		<condition>
 			<and>
-				<not>
-					<equals>
-						<property>sim/model/lights/nose-lights</property>
-						<value>1</value>
-					</equals>
-				</not>
+				<greater-than>
+					<property>sim/model/lights/nose-lights</property>
+					<value>0</value>
+				</greater-than>
+				<less-than>
+					<property>sim/model/lights/nose-lights</property>
+					<value>1</value>
+				</less-than>
 				<greater-than>
 					<property>gear/gear/position-norm</property>
 					<value>0.1</value>


### PR DESCRIPTION
This PR fixes the issue in #384, where the taxi light is left visible after the plane was shut down or the taxi light switch was moved to OFF.

### Description of Changes
<!-- Describe your changes in detail. -->
The nose-light state is exported through the unused multiplayer `float[10]` slot using `/sim/model/lights/nose-lights` so other users can see the correct state of the taxi light in MP.

Before this PR, the condition activated the light if the nose-light value is not equal to one, which is incorrect, since OFF is also not equal to one. I have corrected it to a greater-than-0 and less-than-1 condition for the light.
- `0`: OFF
- Between `0` and `1`: TAXI
- `1`: T.O.

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->
The nose taxi light no longer remains visible on remote multiplayer aircraft when the light switch is OFF.

I tested with the following states:

- OFF: both nose lights off
- TAXI: taxi light visible
- T.O.: nose landing/takeoff light visible
- Nose gear retracted: both lights hidden and nose-light property had changed to 0 correctly.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See Docs/CONTRIBUTING.md to verify. -->
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If your changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
