### PR TITLE
Add PFD high-speed protection marker

### DIFF
--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -537,6 +537,18 @@ var canvas_pfd = {
 					obj["ASI_max"].hide();
 				}
 			}),
+			# Display the high-speed protection marker only when it is valid.
+			props.UpdateManager.FromHashList(["speedError","fac1","fac2","fbwLaw"], 1, func(val) {
+				if (
+					val.speedError or
+					(!val.fac1 and !val.fac2) or
+					val.fbwLaw != 0
+				) {
+					obj["VPROT_MAX"].hide();
+				} else {
+					obj["VPROT_MAX"].show();
+				}
+			}),
 			props.UpdateManager.FromHashList(["speedError","fac1","fac2","ASItrendIsShown"], 1, func(val) {
 				if (!val.speedError and (val.fac1 or val.fac2)) {
 					if (val.ASItrendIsShown == 1) {
@@ -559,6 +571,9 @@ var canvas_pfd = {
 			}),
 			props.UpdateManager.FromHashValue("ASImax", 0.1, func(val) {
 				obj["ASI_max"].setTranslation(0, val * -6.6);
+			}),
+			props.UpdateManager.FromHashValue("vprotMax", 0.1, func(val) {
+				obj["VPROT_MAX"].setTranslation(0, val * -6.6);
 			}),
 			props.UpdateManager.FromHashValue("ASItrend", 0.1, func(val) {
 				obj["ASI_trend_up"].setTranslation(0, math.clamp(val, 0, 50) * -6.6);
@@ -1099,7 +1114,7 @@ var canvas_pfd = {
 	getKeys: func() {
 		return ["FMA_man","FMA_manmode","FMA_flxmode","FMA_flxtemp","FMA_thrust","FMA_lvrclb","FMA_pitch","FMA_pitcharm","FMA_pitcharm2","FMA_roll","FMA_rollarm","FMA_combined","FMA_ctr_msg","FMA_catmode","FMA_cattype","FMA_nodh","FMA_dh","FMA_dhn","FMA_ap",
 		"FMA_fd","FMA_athr","FMA_man_box","FMA_flx_box","FMA_thrust_box","FMA_pitch_box","FMA_pitcharm_box","FMA_roll_box","FMA_rollarm_box","FMA_combined_box","FMA_catmode_box","FMA_cattype_box","FMA_cat_box","FMA_dh_box","FMA_ap_box","FMA_fd_box",
-		"FMA_athr_box","FMA_Middle1","FMA_Middle2","ALPHA_MAX","ALPHA_PROT","ALPHA_SW","ALPHA_bars","VLS_min","ASI_max","ASI_scale","ASI_target","ASI_mach","ASI_trend_up","ASI_trend_down","ASI_digit_UP","ASI_digit_DN","ASI_decimal_UP",
+		"FMA_athr_box","FMA_Middle1","FMA_Middle2","ALPHA_MAX","ALPHA_PROT","ALPHA_SW","ALPHA_bars","VPROT_MAX","VLS_min","ASI_max","ASI_scale","ASI_target","ASI_mach","ASI_trend_up","ASI_trend_down","ASI_digit_UP","ASI_digit_DN","ASI_decimal_UP",
 		"ASI_decimal_DN","ASI_index","ASI_error","ASI_group","ASI_frame","AI_center","AI_bank","AI_bank_lim","AI_bank_lim_X","AI_pitch_lim","AI_pitch_lim_X","AI_slipskid","AI_horizon","AI_horizon_ground","AI_horizon_sky","AI_stick","AI_stick_pos","AI_heading",
 		"AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","ALT_box_flash","ALT_box","ALT_box_amber","ALT_scale","ALT_target","ALT_target_digit","ALT_one","ALT_two","ALT_three","ALT_four","ALT_five","ALT_tens","ALT_digit_UP","ALT_tapes","ALT_hundreds",
 		"ALT_thousands","ALT_thousands_zero","ALT_tenthousands","ALT_digit_DN","ALT_digit_UP_metric","ALT_error","ALT_neg","ALT_group","ALT_group2","ALT_frame","VS_pointer","VS_box","VS_digit","VS_error","VS_group","QNH","QNH_setting","QNH_std","QNH_box",
@@ -1218,6 +1233,15 @@ var canvas_pfd = {
 				notification.ASImax = 390 - notification.ASI;
 			} else {
 				notification.ASImax = fmgc.FMGCInternal.maxspeed - 30 - notification.ASI;
+			}
+
+			# Position the VMO+6/MMO+0.01 marker relative to the moving speed tape.
+			if (notification.vmoMmoPlus6 <= 30) {
+				notification.vprotMax = 0 - notification.ASI;
+			} else if (notification.vmoMmoPlus6 >= 420) {
+				notification.vprotMax = 390 - notification.ASI;
+			} else {
+				notification.vprotMax = notification.vmoMmoPlus6 - 30 - notification.ASI;
 			}
 			
 			if (fmgc.FMGCInternal.v1set) {
@@ -1419,6 +1443,7 @@ var canvas_pfd = {
 			
 			notification.ASI = 0;
 			notification.ASImax = 0;
+			notification.vprotMax = 0;
 			notification.ASItrgt = 0;
 			notification.ASItrgtdiff = 0;
 			notification.ASItrend = 0;
@@ -2303,6 +2328,7 @@ var input = {
 	bussTranslate: "/instrumentation/pfd/buss/translate",
 	overspeedVsProt: "/it-autoflight/internal/overspeed-vs-prot",
 	underspeedVsProt: "/it-autoflight/internal/underspeed-vs-prot",
+	vmoMmoPlus6: "/FMGC/internal/vmo-mmo-plus-6",
 	valphaMax: "/FMGC/internal/valpha-max",
 	valphaProt: "/FMGC/internal/valpha-prot",
 	vls: "/FMGC/internal/vls",

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -1413,6 +1413,14 @@
      width="21.356052"
      id="ASI_max_clip"
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       inkscape:label="#rect9211"
+       y="237.03366"
+       x="82"
+       height="552.00073"
+       width="66"
+       id="VPROT_MAX_clip"
+       style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
      style="opacity:0.46000001;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.27696717;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="ALT_target_clip"
@@ -6565,7 +6573,18 @@
          x="80.506668"
          id="tspan4696"
          sodipodi:role="line">.</tspan></text>
-  </g>
+
+      <g
+         id="VPROT_MAX"
+         style="display:inline">
+        <path
+           d="m 91.5,509.5 h 22"
+           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           d="m 91.5,517.5 h 22"
+           style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:3.2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
   <path
      inkscape:label="#rect902"
      sodipodi:nodetypes="cccc"


### PR DESCRIPTION
### Description of Changes

This PR adds the green high-speed protection marker (`=`) to the PFD airspeed scale.

Since the A320 FMGC already calculates VMO and MMO, my implementation reuses the property `/FMGC/internal/vmo-mmo-plus-6` value and positions it at VMO + 6kts or MMO + 0,01. It moves along with the airspeed scale correctly, clipped to the visible speed tape area, and is only displayed in NORMAL law with valid airspeed data and at least one FAC available. It is hidden in degraded laws such as ALTERNATE or DIRECT, or when both FACs are unavailable.

### Screenshots (optional)

Normal Law:
<img width="520" height="542" alt="Screenshot 2026-07-25 at 11 06 49" src="https://github.com/user-attachments/assets/05473703-b49f-47ba-aaae-53dde941675c" />
<img width="532" height="553" alt="Screenshot 2026-07-25 at 11 07 03" src="https://github.com/user-attachments/assets/6d0146df-4abe-421a-af8a-698d615f9a9f" />
Degraded Law:
<img width="515" height="540" alt="Screenshot 2026-07-25 at 11 08 03" src="https://github.com/user-attachments/assets/ab922282-9ae6-4107-86d6-49b6c044c0c6" />
<img width="514" height="498" alt="Screenshot 2026-07-25 at 11 08 10" src="https://github.com/user-attachments/assets/0bb34f7a-ff4e-4d78-90bb-bc7b0a5afe4e" />
### Bugs fixed (if any)

Fixes #411.

### Checklist:

* [x] My changes follow the Contributing Guidelines.
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.