### PR TITLE
Use multiplayer property for remote nose lights

### DIFF
--- a/Models/A320-common.xml
+++ b/Models/A320-common.xml
@@ -794,13 +794,13 @@
 			<and>
 				<not>
 					<equals>
-						<property>sim/model/lights/nose-lights</property>
+						<property>sim/multiplay/generic/float[10]</property>
 						<value>1.0</value>
 					</equals>
 				</not>
 				<not>
 					<equals>
-						<property>sim/model/lights/nose-lights</property>
+						<property>sim/multiplay/generic/float[10]</property>
 						<value>0.0</value>
 					</equals>
 				</not>
@@ -818,7 +818,7 @@
 		<condition>
 			<and>
 				<equals>
-					<property>sim/model/lights/nose-lights</property>
+					<property>sim/multiplay/generic/float[10]</property>
 					<value>1.0</value>
 				</equals>
 				<greater-than>
@@ -895,7 +895,7 @@
 		<condition>
 			<and>
 				<equals>
-					<property>sim/model/lights/nose-lights</property>
+					<property>sim/multiplay/generic/float[10]</property>
 					<value>1</value>
 				</equals>
 				<greater-than>
@@ -912,11 +912,11 @@
 		<condition>
 			<and>
 				<greater-than>
-					<property>sim/model/lights/nose-lights</property>
+					<property>sim/multiplay/generic/float[10]</property>
 					<value>0</value>
 				</greater-than>
 				<less-than>
-					<property>sim/model/lights/nose-lights</property>
+					<property>sim/multiplay/generic/float[10]</property>
 					<value>1</value>
 				</less-than>
 				<greater-than>
@@ -927,4 +927,3 @@
 		</condition>
 	</animation>
 </PropertyList>
-

--- a/Models/Lights/taxilight.eff
+++ b/Models/Lights/taxilight.eff
@@ -15,7 +15,7 @@
    <light_color_center_r type="float">1.00</light_color_center_r> <!-- aviation white converted from 5500 K temp -->
     <light_color_center_g type="float">0.93</light_color_center_g>
     <light_color_center_b type="float">0.87</light_color_center_b>
-    <intensity_scale type="float"><use>/sim/model/lights/nose-lights</use></intensity_scale>
+    <intensity_scale type="float"><use>sim/multiplay/generic/float[10]</use></intensity_scale>
     <pointing_x type="float">1</pointing_x>
     <pointing_y type="float">0.0</pointing_y>
     <pointing_z type="float">0.0</pointing_z>


### PR DESCRIPTION
### Description of Changes

This PR will fix the problems that #415 overlooked.

The A320 already transmits the nose-light state through
`sim/multiplay/generic/float[10]`. However, the remote aircraft's nose-light
animations still read `sim/model/lights/nose-lights`, so they do not use the
value received over multiplayer.

I changed all six nose-light animation references in
`Models/A320-common.xml` to read
`sim/multiplay/generic/float[10]` directly.

The affected animations are:

- Taxi Light Compositor
- Nose Landing Light Compositor
- Nosegear landing light ALS
- Second Nosegear landing light ALS

### Screenshots (optional)

None, I-FABI will help me test this.

### Bugs fixed (if any)

Addresses #384.

This should allow the remote aircraft's nose lights to follow the transmitting
aircraft's OFF, TAXI, and T.O. states correctly.

@I-FABI, please test this PR using two multiplayer sessions and confirm whether
the original issue is resolved.

### Checklist:

* [x] My changes follow the Contributing Guidelines.
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.