### PR TITLE
WIP: implement tiller pedal disconnect for testing

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1075,6 +1075,7 @@
 			<brake-parking type="bool">0</brake-parking>
 			<lever-cockpit type="int">3</lever-cockpit>
 			<nws-switch type="double">1</nws-switch>
+			<pedal-disc type="bool">0</pedal-disc>
 			<tiller-cmd-norm type="double">0</tiller-cmd-norm>
 			<tiller-enabled type="bool">0</tiller-enabled>
 		</gear>
@@ -5175,4 +5176,3 @@
 	</maintainance>
 
 </PropertyList>
-

--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -3515,6 +3515,23 @@
 		<type>pick</type>
 		<object-name>tiller</object-name>
 		<object-name>tillerFo</object-name>
+		<!-- Temporary PEDAL DISC functional test -->
+		<action>
+			<button>1</button>
+			<repeatable>false</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>controls/gear/pedal-disc</property>
+				<value type="bool">true</value>
+			</binding>
+			<mod-up>
+				<binding>
+					<command>property-assign</command>
+					<property>controls/gear/pedal-disc</property>
+					<value type="bool">false</value>
+				</binding>
+			</mod-up>
+		</action>
 		<action>
 			<button>3</button>
 			<repeatable>true</repeatable>
@@ -43421,4 +43438,3 @@
 	</light>
 	
 </PropertyList>
-

--- a/Systems/a320-fcs.xml
+++ b/Systems/a320-fcs.xml
@@ -1218,9 +1218,16 @@
 				</tableData>
 			</table>
 		</scheduled_gain>
-		
-		<switch name="/systems/fcs/tiller/rudder-cmd-input">
+
+		<switch name="/systems/fcs/tiller/rudder-cmd-connected">
 			<default value="/systems/fbw/sidestick/yaw-input"/>
+			<test value="0">
+				/controls/gear/pedal-disc eq 1
+			</test>
+		</switch>
+
+		<switch name="/systems/fcs/tiller/rudder-cmd-input">
+			<default value="/systems/fcs/tiller/rudder-cmd-connected"/>
 			<test value="/systems/fbw/sidestick/roll-input">
 				/controls/flight/aileron-drives-tiller eq 1
 			</test>


### PR DESCRIPTION
### Description of Changes

I implemented the tiller PEDAL DISC feature requested in #422. As It's the first time I'm fiddling around with aircraft interactions, I created this as a draft PR.

The changes:

- Add the `/controls/gear/pedal-disc` property.
- Disconnect rudder-pedal input from nosewheel steering while PEDAL DISC is active.
- Preserve separate tiller-axis steering while the rudder pedals are disconnected.
- Preserve the `aileron-drives-tiller` accessibility behavior.
- Add a temporary cockpit interaction:

  - Hold middle-click on either tiller to activate PEDAL DISC.
  - Release middle-click to deactivate PEDAL DISC.

Right now, the cockpit model does not export the PEDAL DISC buttons as separate 3D objects. Because of this, middle-clicking the complete `tiller` or `tillerFo` mesh is used as a temporary testing interface.

A final implementation probably requires separate clickable objects such as `tiller.pedal-disc` and `tillerFo.pedal-disc`.

This implementation has not been tested in FlightGear by me and is being submitted as a draft for testing(Cause I use a MacBook with a trackpad only, not really convenient without a mouse).

### Screenshots (optional)

Not applicable. This change currently uses a temporary mouse interaction and does not include a visible cockpit-model change.

### Bugs fixed (if any)

Implements the feature requested in #422.

### Checklist:

* [x] My changes follow the Contributing Guidelines.
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.
