### PR TITLE
Fix FO ACP volume control

### DIFF
--- a/Systems/a320-audio.xml
+++ b/Systems/a320-audio.xml
@@ -10,37 +10,37 @@
 		<switch name="/instrumentation/comm[0]/volume">
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf1-volume">
-				/controls/audio/acp[0]/vhf1-receive eq 1
 				/options/system/fo-view eq 0
+				/controls/audio/acp[0]/vhf1-receive eq 1
 			</test>
 				<!-- If FO's ACP is set as main instrument -->
 			<test logic="AND" value="/controls/audio/acp[1]/vhf1-volume">
-				/controls/audio/acp[1]/vhf1-receive eq 1
 				/options/system/fo-view eq 1
+				/controls/audio/acp[1]/vhf1-receive eq 1
 			</test>
 		</switch>
 		<switch name="/instrumentation/comm[1]/volume">
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf2-volume">
-				/controls/audio/acp[0]/vhf2-receive eq 1
 				/options/system/fo-view eq 0
+				/controls/audio/acp[0]/vhf2-receive eq 1
 			</test>
 				<!-- If FO's ACP is set as main instrument -->
 			<test logic="AND" value="/controls/audio/acp[1]/vhf2-volume">
-				/controls/audio/acp[1]/vhf2-receive eq 1
 				/options/system/fo-view eq 1
+				/controls/audio/acp[1]/vhf2-receive eq 1
 			</test>
 		</switch>
 		<switch name="/instrumentation/comm[2]/volume">
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf3-volume">
-				/controls/audio/acp[0]/vhf3-receive eq 1
 				/options/system/fo-view eq 0
+				/controls/audio/acp[0]/vhf3-receive eq 1
 			</test>
 				<!-- If FO's ACP is set as main instrument -->
 			<test logic="AND" value="/controls/audio/acp[1]/vhf3-volume">
-				/controls/audio/acp[1]/vhf3-receive eq 1
 				/options/system/fo-view eq 1
+				/controls/audio/acp[1]/vhf3-receive eq 1
 			</test>
 		</switch>
 	</channel>

--- a/Systems/a320-audio.xml
+++ b/Systems/a320-audio.xml
@@ -11,18 +11,36 @@
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf1-volume">
 				/controls/audio/acp[0]/vhf1-receive eq 1
+				/options/system/fo-view eq 0
+			</test>
+				<!-- If FO's ACP is set as main instrument -->
+			<test logic="AND" value="/controls/audio/acp[1]/vhf1-volume">
+				/controls/audio/acp[1]/vhf1-receive eq 1
+				/options/system/fo-view eq 1
 			</test>
 		</switch>
 		<switch name="/instrumentation/comm[1]/volume">
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf2-volume">
 				/controls/audio/acp[0]/vhf2-receive eq 1
+				/options/system/fo-view eq 0
+			</test>
+				<!-- If FO's ACP is set as main instrument -->
+			<test logic="AND" value="/controls/audio/acp[1]/vhf2-volume">
+				/controls/audio/acp[1]/vhf2-receive eq 1
+				/options/system/fo-view eq 1
 			</test>
 		</switch>
 		<switch name="/instrumentation/comm[2]/volume">
 			<default value="0"/>
 			<test logic="AND" value="/controls/audio/acp[0]/vhf3-volume">
 				/controls/audio/acp[0]/vhf3-receive eq 1
+				/options/system/fo-view eq 0
+			</test>
+				<!-- If FO's ACP is set as main instrument -->
+			<test logic="AND" value="/controls/audio/acp[1]/vhf3-volume">
+				/controls/audio/acp[1]/vhf3-receive eq 1
+				/options/system/fo-view eq 1
 			</test>
 		</switch>
 	</channel>

--- a/Systems/a320-audio.xml
+++ b/Systems/a320-audio.xml
@@ -4,6 +4,8 @@
 <!-- Copyright (c) 2025 Nia -->
 <!-- Note, this is limited by flightgears current audio capabilities -->
 
+<!-- ABILITY TO SWITCH ACP'S ACCORDING TO FO SETTING IS A WORKAROUND AND SHOULD BE REMOVED ONCE MOVED UPWARDS (swift-plugin, Swift itself) -->
+
 <system name="A320: Audio">
 
 	<property value="0">/systems/draims/rmp[0]/audioNavSelected</property>


### PR DESCRIPTION
Fixes the ability to select the FO ACP as the main device for controlling volume, e.g. for usw with Swift.

### Description of Changes
Till recently, the Setting "First Officer is pilot flying" in the Settings GUI enabled the user to select which ACP/RMP was being used to output volume levels to the property /instruments/comm[x]/volume (as well as whether the respective VHF channel was switched on). This is handy is these values are read by the swift plugin to control VATSIM audio in the pilot client, allowing to fly from the First Officers seat and control levels from there.

This feature broke as a result of code optimization in https://github.com/legoboyvdlp/A320-family/commit/6c09eaf954f233a88d0932e7e164258179037fc9. As the removed code was indeed pretty nasty and a weird workaround, I made things easier by implementing it in the a320-audio.xml JSBsim file. JSBsim will check whether the FO property is set and pass along the volume and activiation levels to the desired property. 

In the future I will try to look into the swift plugin and see if there would be a better way to do this task. 

### Screenshots (optional)

### Bugs fixed (if any)
Settings property "First Officer is the Pilot Flying" (/options/system/fo-view) was rendered uneffective by code removal. The functionality has been restored in a simpler fashion.

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See Docs/CONTRIBUTING.md to verify. -->
* [x] My changes have been created without the use of "AI" and LLMs.
* [ ] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have a main Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->

<!-- If you changes are not ready for merging, please submit this as a draft pull request. If it is ready, submit it as a regular pull request. -->
