### PR TITLE
Add PFD ground roll guidance yaw bar

### DIFF
--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -148,6 +148,7 @@ var canvas_pfd = {
 		# init hidden objects
 		obj["LOC_scale"].hide();
 		obj["GS_scale"].hide();
+		obj["FD_yaw"].hide();
 		
 		obj.temporaryNodes = {
 			showGroundReferenceAGL: 0,
@@ -200,6 +201,12 @@ var canvas_pfd = {
 			}),
 			props.UpdateManager.FromHashValue("FDRollBar", 0.1, func(val) {
 				obj["FD_roll"].setTranslation(val * 2.2, 0);
+			}),
+			props.UpdateManager.FromHashValue("FDYawBar", 0.001, func(val) {
+				obj["FD_yaw"].setTranslation(
+					math.clamp(val, -5, 5) * 20,
+					0
+				);
 			}),
 			props.UpdateManager.FromHashValue("FDPitchBar", 0.1, func(val) {
 				obj["FD_pitch"].setTranslation(0, val * -11.825);
@@ -1116,7 +1123,7 @@ var canvas_pfd = {
 		"FMA_fd","FMA_athr","FMA_man_box","FMA_flx_box","FMA_thrust_box","FMA_pitch_box","FMA_pitcharm_box","FMA_roll_box","FMA_rollarm_box","FMA_combined_box","FMA_catmode_box","FMA_cattype_box","FMA_cat_box","FMA_dh_box","FMA_ap_box","FMA_fd_box",
 		"FMA_athr_box","FMA_Middle1","FMA_Middle2","ALPHA_MAX","ALPHA_PROT","ALPHA_SW","ALPHA_bars","VPROT_MAX","VLS_min","ASI_max","ASI_scale","ASI_target","ASI_mach","ASI_trend_up","ASI_trend_down","ASI_digit_UP","ASI_digit_DN","ASI_decimal_UP",
 		"ASI_decimal_DN","ASI_index","ASI_error","ASI_group","ASI_frame","AI_center","AI_bank","AI_bank_lim","AI_bank_lim_X","AI_pitch_lim","AI_pitch_lim_X","AI_slipskid","AI_horizon","AI_horizon_ground","AI_horizon_sky","AI_stick","AI_stick_pos","AI_heading",
-		"AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","ALT_box_flash","ALT_box","ALT_box_amber","ALT_scale","ALT_target","ALT_target_digit","ALT_one","ALT_two","ALT_three","ALT_four","ALT_five","ALT_tens","ALT_digit_UP","ALT_tapes","ALT_hundreds",
+		"AI_agl_g","AI_agl","AI_error","AI_group","FD_roll","FD_pitch","FD_yaw","ALT_box_flash","ALT_box","ALT_box_amber","ALT_scale","ALT_target","ALT_target_digit","ALT_one","ALT_two","ALT_three","ALT_four","ALT_five","ALT_tens","ALT_digit_UP","ALT_tapes","ALT_hundreds",
 		"ALT_thousands","ALT_thousands_zero","ALT_tenthousands","ALT_digit_DN","ALT_digit_UP_metric","ALT_error","ALT_neg","ALT_group","ALT_group2","ALT_frame","VS_pointer","VS_box","VS_digit","VS_error","VS_group","QNH","QNH_setting","QNH_std","QNH_box",
 		"LOC_pointer","LOC_scale","GS_scale","GS_pointer","CRS_pointer","HDG_target","HDG_scale","HDG_one","HDG_two","HDG_three","HDG_four","HDG_five","HDG_six","HDG_seven","HDG_digit_L","HDG_digit_R","HDG_error","HDG_group","HDG_frame","TRK_pointer","machError",
 		"ilsError","ils_code","ils_freq","dme_dist","dme_dist_legend","ILS_HDG_R","ILS_HDG_L","ILS_right","ILS_left","outerMarker","middleMarker","innerMarker","v1_group","v1_text","vr_speed","F_target","S_target","FS_targets","flap_max","clean_speed","ground",
@@ -2017,25 +2024,61 @@ var canvas_pfd = {
 			me["FMA_thrust_box"].setColor(0.8078,0.8039,0.8078);
 		}
 		
-		if (((me.number == 0 and notification.fd1) or (me.number == 1 and notification.fd2)) and notification.pitchPFD < 25 and notification.pitchPFD > -13 and notification.roll < 45 and notification.roll > -45) {
-			if (notification.trkFpa) {
+		var fdActive =
+			((me.number == 0 and notification.fd1) or
+			(me.number == 1 and notification.fd2));
+
+		var yawBarActive =
+			notification.agl <= 30 and
+			notification.hasLocalizer and
+			(
+				fmgc.Modes.PFD.FMA.rollMode == "RWY" or
+				fmgc.Modes.PFD.FMA.pitchMode == "FLARE" or
+				fmgc.Modes.PFD.FMA.pitchMode == "ROLL OUT"
+			);
+
+		if (fdActive and
+			notification.pitchPFD < 25 and
+			notification.pitchPFD > -13 and
+			notification.roll < 45 and
+			notification.roll > -45) {
+
+			if (yawBarActive) {
+				me["FPD"].hide();
+				me["FD_roll"].hide();
+				me["FD_yaw"].show();
+
+				if (fmgc.Modes.PFD.FMA.pitchMode != " " and
+					fmgc.Modes.PFD.FMA.pitchMode != "ROLL OUT") {
+					me["FD_pitch"].show();
+				} else {
+					me["FD_pitch"].hide();
+				}
+
+			} else if (notification.trkFpa) {
 				me["FD_roll"].hide();
 				me["FD_pitch"].hide();
-				
-				if (fmgc.Modes.PFD.FMA.rollMode != " " and fmgc.Modes.PFD.FMA.pitchMode != " " and !notification.gear1Wow) {
+				me["FD_yaw"].hide();
+
+				if (fmgc.Modes.PFD.FMA.rollMode != " " and
+					fmgc.Modes.PFD.FMA.pitchMode != " " and
+					!notification.gear1Wow) {
 					me["FPD"].show();
 				} else {
 					me["FPD"].hide();
 				}
+
 			} else {
 				me["FPD"].hide();
-				
-				if (fmgc.Modes.PFD.FMA.rollMode != " " and !notification.gear1Wow) {
+				me["FD_yaw"].hide();
+
+				if (fmgc.Modes.PFD.FMA.rollMode != " " and
+					!notification.gear1Wow) {
 					me["FD_roll"].show();
 				} else {
 					me["FD_roll"].hide();
 				}
-				
+
 				if (fmgc.Modes.PFD.FMA.pitchMode != " ") {
 					me["FD_pitch"].show();
 				} else {
@@ -2046,6 +2089,7 @@ var canvas_pfd = {
 			me["FPD"].hide();
 			me["FD_roll"].hide();
 			me["FD_pitch"].hide();
+			me["FD_yaw"].hide();
 		}
 		
 		foreach(var update_item; me.update_items)
@@ -2243,6 +2287,7 @@ var input = {
 	du6Lgt: "/controls/lighting/DU/du6",
 	attSwitch: "/controls/navigation/switching/att-hdg",
 	managedAlt: "/it-autoflight/internal/mng-alt",
+	agl: "/position/gear-agl-ft",
 	
 	athr: "/it-autoflight/output/athr",
 	altitudeAutopilot: "/it-autoflight/internal/alt",
@@ -2253,6 +2298,7 @@ var input = {
 	slipSkid: "/instrumentation/pfd/slip-skid",
 	fbwLaw: "/it-fbw/law",
 	FDRollBar: "/it-autoflight/fd/roll-bar",
+	FDYawBar: "/it-autoflight/fd/yaw-bar",
 	FDPitchBar: "/it-autoflight/fd/pitch-bar",
 	FPDPitch: "/it-autoflight/fd/fpd-pitch",
 	vsAutopilot: "/it-autoflight/internal/vert-speed-fpm",

--- a/Models/Instruments/PFD/PFD.nas
+++ b/Models/Instruments/PFD/PFD.nas
@@ -202,6 +202,7 @@ var canvas_pfd = {
 			props.UpdateManager.FromHashValue("FDRollBar", 0.1, func(val) {
 				obj["FD_roll"].setTranslation(val * 2.2, 0);
 			}),
+			# Ground-roll guidance needs to respond quickly to yaw corrections.
 			props.UpdateManager.FromHashValue("FDYawBar", 0.001, func(val) {
 				obj["FD_yaw"].setTranslation(
 					math.clamp(val, -5, 5) * 20,
@@ -2028,6 +2029,7 @@ var canvas_pfd = {
 			((me.number == 0 and notification.fd1) or
 			(me.number == 1 and notification.fd2));
 
+		# Below 30 ft, RWY/FLARE/ROLL OUT use the yaw command bar instead of the roll FD bar.
 		var yawBarActive =
 			notification.agl <= 30 and
 			notification.hasLocalizer and

--- a/Models/Instruments/PFD/res/pfd.svg
+++ b/Models/Instruments/PFD/res/pfd.svg
@@ -986,6 +986,11 @@
        x="437.25876"
        y="504.91898"
        inkscape:label="#rect4741" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#0dc04b;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="FD_yaw"
+         d="m 445.257,522 5,9 v 90 h -10 v -90 z"
+         inkscape:label="#FD_yaw" />
     <g
        id="g4844"
        transform="matrix(1.0666667,0,0,1.066636,1.9196363,-0.50381959)">

--- a/Nasal/FMGC/FMGC-b.nas
+++ b/Nasal/FMGC/FMGC-b.nas
@@ -83,6 +83,7 @@ var Velocities = {
 var Fd = {
 	pitchBar: props.globals.initNode("/it-autoflight/fd/pitch-bar", 0, "DOUBLE"),
 	rollBar: props.globals.initNode("/it-autoflight/fd/roll-bar", 0, "DOUBLE"),
+	yawBar: props.globals.initNode("/it-autoflight/fd/yaw-bar", 0, "DOUBLE"),
 };
 
 var Input = {

--- a/Systems/fmgc-drivers.xml
+++ b/Systems/fmgc-drivers.xml
@@ -953,6 +953,21 @@
 		<max>30</max>
 		<max-rate-of-change>20</max-rate-of-change>
 	</filter>
+
+	<filter>
+		<name>FD Yaw</name>
+		<type>gain</type>
+		<gain>1.0</gain>
+		<input>
+			<expression>
+				<difference>
+					<property>/it-autoflight/internal/yaw-rate</property>
+					<property>/orientation/yaw-rate-degps</property>
+				</difference>
+			</expression>
+		</input>
+		<output>/it-autoflight/fd/yaw-bar</output>
+	</filter>
 	
 	<filter>
 		<name>FD Pitch Takeoff Schedule</name>

--- a/Systems/fmgc-drivers.xml
+++ b/Systems/fmgc-drivers.xml
@@ -954,6 +954,7 @@
 		<max-rate-of-change>20</max-rate-of-change>
 	</filter>
 
+	<!-- Ground-roll FD yaw guidance: target yaw rate minus actual yaw rate. -->
 	<filter>
 		<name>FD Yaw</name>
 		<type>gain</type>

--- a/Systems/fmgc-drivers.xml
+++ b/Systems/fmgc-drivers.xml
@@ -670,8 +670,9 @@
 		<gain>1.0</gain>
 		<input>
 			<property>/instrumentation/nav[0]/radials/selected-deg</property>
+			<!-- NAV selected course is true-referenced; compare against true aircraft heading. -->
 			<offset>
-				<property>/orientation/heading-magnetic-deg</property>
+				<property>/orientation/heading-deg</property>
 				<scale>-1.0</scale>
 			</offset>
 		</input>

--- a/Systems/fmgc-drivers.xml
+++ b/Systems/fmgc-drivers.xml
@@ -670,9 +670,8 @@
 		<gain>1.0</gain>
 		<input>
 			<property>/instrumentation/nav[0]/radials/selected-deg</property>
-			<!-- NAV selected course is true-referenced; compare against true aircraft heading. -->
 			<offset>
-				<property>/orientation/heading-deg</property>
+				<property>/orientation/heading-magnetic-deg</property>
 				<scale>-1.0</scale>
 			</offset>
 		</input>


### PR DESCRIPTION
### Description of Changes

I added the Ground Roll Guidance Command Bar (yaw bar) to the Primary Flight Display.

Changes include:

- Adds `/it-autoflight/fd/yaw-bar`, derived from the existing commanded yaw rate and aircraft yaw rate.
- Adds the outlined green yaw guidance symbol below the aircraft reference.
- Displays yaw guidance below 30 ft RA when RWY, FLARE, or ROLL OUT guidance is applicable, and a localizer is available.
- Replaces the normal roll flight-director bar while yaw guidance is displayed.
- Hides the pitch flight-director bar during ROLL OUT.
- Uses a higher display update rate for responsive yaw guidance.

I reused existing FMGC ALIGN/ROLLOUT guidance, not a separate calculation for this feature.

This change does not include Automatic RWY mode engagement. The existing FMGC currently has a TODO for automatic ILS selection / RWY engagement, so RWY mode was manually engaged during testing. The only way to trigger it at the moment is to use this command inside Nasal Console.

```nasal
fmgc.ITAF.setLatMode(5);
```
I'll follow up with automatic RWY engagement soon to complete this.

### Screenshots (optional)

**Canvas**:
<img width="519" height="542" alt="Screenshot 2026-09-05 at 17 33 44" src="https://github.com/user-attachments/assets/b8cc102f-f78c-4127-9f26-c1d545f6250a" />
**Pilot close view**:
<img width="618" height="637" alt="Screenshot 2026-09-05 at 17 34 10" src="https://github.com/user-attachments/assets/38c4c92b-a686-47f1-a7ef-7f65235c0cb5" />

### Bugs fixed (if any)

None.

Related to the missing PFD feature tracked in #125.

### Checklist:
* [x] My changes follow the Contributing Guidelines.
* [x] My changes have been created without the use of "AI" and LLMs.
* [x] My changes implement realistic features.
* [x] Please have a main Developer test my changes before merging.